### PR TITLE
Update link-checker.yml schedule to run once a month

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -2,8 +2,8 @@ name: Check Broken links
 
 on:
     workflow_dispatch:
-    schedule: # Run every Sunday at 6 am
-        - cron: '00 06 * * 0'
+    schedule: # Run once a month
+        - cron: '0 0 1 * *'
 jobs:
     linkChecker:
         runs-on: ubuntu-latest


### PR DESCRIPTION
I believe that running this once a month should be enough. So we can avoid: 

![image](https://github.com/user-attachments/assets/176c1a93-5c06-4c26-a2b8-5824f7641355)

 
# Pull Request Template

Please ensure all items below are checked before creating a pull request:

-   [ ] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
-   [ ] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
-   [ ] My submission is ordered alphabetically based on the resource `name`
-   [ ] My submission has a useful description
-   [ ] I have searched the repository for any relevant issues or pull requests
