### PR TITLE
[test] Modify db folder -  Warning

### DIFF
--- a/db/categories.json
+++ b/db/categories.json
@@ -18,14 +18,6 @@
         "slug": "animation"
     },
     {
-        "name": "API Building",
-        "slug": "api-building"
-    },
-    {
-        "name": "Audio",
-        "slug": "audio"
-    },
-    {
         "name": "Authentication",
         "slug": "authentication"
     },


### PR DESCRIPTION
This should flag the PR with a warning
 #870

This pull request modifies the `db/categories.json` file to remove unused or obsolete categories. Specifically, the "API Building" and "Audio" categories have been deleted to streamline the list of available categories.