### PR TITLE
Ignore Jetbrains IDE config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 # gatsby
 .cache
+
+# jetbrains
+.idea/


### PR DESCRIPTION
# Motivation

I'm using WebStorm and got a few files that were suggested to be committed when I prepared a [PR](#975). Therefore, I propose adding the JetBrains config to the list of ignored files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added .idea/ to .gitignore to prevent committing JetBrains IDE project files. This reduces noise in PRs and avoids sharing local IDE settings.

<sup>Written for commit b92d7d855b46de850b322c17919600afbc73b30e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

