### PR TITLE
Document how to run prettier in CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,8 @@ Contributions not related to the resources are also welcome, but please open an 
 
 This project relies on [Prettier](https://prettier.io/) and [ESLint](https://eslint.org/) for code formatting and error/standards checking, so please ensure you have both installed globally or run `npm install` in order to install them in the project directory.
 
+> Tip: You can format your contribution with the command `npm run prettier:format` 
+
 ## Updating README and DB
 
 This repository uses a GitHub action to automatically update `README.md` and `db` (which serves our API), so no action is required from you.


### PR DESCRIPTION
# Motivation

When I prepared a [PR](#975) I followed the CONTRIBUTING guide but, while prettier is mentionned as formatting tools, there was no mention on the command to run it. That's why here I'm suggesting to add a "Tip" to share this command within the guide.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented how to run Prettier in CONTRIBUTING.md to make formatting steps clear for contributors. Adds a tip with the command: npm run prettier:format.

<sup>Written for commit 0ab3ced26ecbff4f1a27618f8f7120dd4375baa6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

