### PR TITLE
Add FrontendAtlas resource

### DIFF
--- a/resources/f.ts
+++ b/resources/f.ts
@@ -595,25 +595,6 @@ export const resources: Resource[] = [
         url: 'https://frontendhappyhour.com/',
     },
     {
-        name: 'FrontendAtlas',
-        description:
-            'Frontend interview prep platform with hands-on JavaScript, UI, and DOM-oriented coding challenges.',
-        categories: ['Code Challenge', 'Learn', 'Programming'],
-        url: 'https://frontendatlas.com/coding',
-        keywords: [
-            'frontend',
-            'javascript',
-            'typescript',
-            'ui',
-            'dom',
-            'react',
-            'angular',
-            'vue',
-            'interview',
-            'system design',
-        ],
-    },
-    {
         name: 'Frontend Focus',
         description:
             'A once–weekly roundup of the best front-end news, articles and tutorials. HTML, CSS, WebGL, Canvas, browser tech, and more.',
@@ -646,6 +627,25 @@ export const resources: Resource[] = [
             'Frontend Toolkit is a customizable dashboard for your recurring Frontend tasks. Base64 encoder/decoder, SVG optimizations, SVG to JSX and many more!',
         categories: ['Productivity', 'Programming'],
         url: 'https://www.fetoolkit.io/',
+    },
+    {
+        name: 'FrontendAtlas',
+        description:
+            'Frontend interview prep platform with hands-on JavaScript, UI, and DOM-oriented coding challenges.',
+        categories: ['Code Challenge', 'Learn', 'Programming'],
+        url: 'https://frontendatlas.com/coding',
+        keywords: [
+            'frontend',
+            'javascript',
+            'typescript',
+            'ui',
+            'dom',
+            'react',
+            'angular',
+            'vue',
+            'interview',
+            'system design',
+        ],
     },
     {
         name: 'Frontendor',

--- a/resources/f.ts
+++ b/resources/f.ts
@@ -595,6 +595,25 @@ export const resources: Resource[] = [
         url: 'https://frontendhappyhour.com/',
     },
     {
+        name: 'FrontendAtlas',
+        description:
+            'Frontend interview prep platform with hands-on JavaScript, UI, and DOM-oriented coding challenges.',
+        categories: ['Code Challenge', 'Learn', 'Programming'],
+        url: 'https://frontendatlas.com/coding',
+        keywords: [
+            'frontend',
+            'javascript',
+            'typescript',
+            'ui',
+            'dom',
+            'react',
+            'angular',
+            'vue',
+            'interview',
+            'system design',
+        ],
+    },
+    {
         name: 'Frontend Focus',
         description:
             'A once–weekly roundup of the best front-end news, articles and tutorials. HTML, CSS, WebGL, Canvas, browser tech, and more.',


### PR DESCRIPTION
# Pull Request Template

This PR adds FrontendAtlas to `resources/f.ts`.

FrontendAtlas is a frontend interview prep platform focused on hands-on JavaScript, UI, and DOM-oriented coding challenges.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] I have searched the repository for any relevant issues or pull requests