### PR TITLE
Fix category validation and alphabetical order for Screenshot to Code

### DIFF
--- a/resources/s.ts
+++ b/resources/s.ts
@@ -107,6 +107,13 @@ export const resources: Resource[] = [
         keywords: ['screenshot api', 'screenshot automation', 'screenshot service'],
     },
     {
+      name: 'Screenshot to Code',
+      description: 'Tool for converting screenshots and UI mockups into frontend code to accelerate prototyping workflows.',
+      categories: ['AI', 'Programming'],
+      url: 'https://screenshottocode.net/',
+      keywords: ['screenshot', 'ui', 'frontend', 'prototyping', 'react', 'tailwind'],
+    },
+    {
         name: 'Screenstab',
         description: 'Turn ordinary screenshots into beautiful image assets in no time',
         categories: ['Screenshot'],
@@ -1043,13 +1050,6 @@ export const resources: Resource[] = [
         categories: ['Analytics'],
         url: 'https://swetrix.com',
         keywords: ['analytics', 'marketing', 'web analytics', 'privacy', 'opensource'],
-    },
-    {
-      name: 'Screenshot to Code',
-      description: 'Tool for converting screenshots and UI mockups into frontend code to accelerate prototyping workflows.',
-      categories: ['AI', 'Programming'],
-      url: 'https://screenshottocode.net/',
-      keywords: ['screenshot', 'ui', 'frontend', 'prototyping', 'react', 'tailwind'],
     },
     {
         name: 'Syntax',

--- a/resources/s.ts
+++ b/resources/s.ts
@@ -1051,4 +1051,11 @@ export const resources: Resource[] = [
         categories: ['Podcast', 'Programming'],
         url: 'https://syntax.fm',
     },
+    {
+      name: 'Screenshot to Code',
+      description: 'Tool for converting screenshots and UI mockups into frontend code to accelerate prototyping workflows.',
+      categories: ['AI', 'Frontend', 'Tools'],
+      url: 'https://screenshottocode.net/',
+      keywords: ['screenshot', 'ui', 'frontend', 'prototyping', 'react', 'tailwind'],
+    },
 ]

--- a/resources/s.ts
+++ b/resources/s.ts
@@ -1045,17 +1045,17 @@ export const resources: Resource[] = [
         keywords: ['analytics', 'marketing', 'web analytics', 'privacy', 'opensource'],
     },
     {
+      name: 'Screenshot to Code',
+      description: 'Tool for converting screenshots and UI mockups into frontend code to accelerate prototyping workflows.',
+      categories: ['AI', 'Programming'],
+      url: 'https://screenshottocode.net/',
+      keywords: ['screenshot', 'ui', 'frontend', 'prototyping', 'react', 'tailwind'],
+    },
+    {
         name: 'Syntax',
         description:
             'Full Stack Developers Wes Bos and Scott Tolinski dive deep into web development topics, explaining how they work and talking about their own experiences. They cover from JavaScript frameworks like React, to the latest advancements in CSS to simplifying web tooling.',
         categories: ['Podcast', 'Programming'],
         url: 'https://syntax.fm',
-    },
-    {
-      name: 'Screenshot to Code',
-      description: 'Tool for converting screenshots and UI mockups into frontend code to accelerate prototyping workflows.',
-      categories: ['AI', 'Frontend', 'Tools'],
-      url: 'https://screenshottocode.net/',
-      keywords: ['screenshot', 'ui', 'frontend', 'prototyping', 'react', 'tailwind'],
     },
 ]


### PR DESCRIPTION
## Summary

This PR fixes the Screenshot to Code resource entry by updating the categories and placing it in the correct alphabetical position in `resources/s.ts`.

## Changes made

- Moved `Screenshot to Code` before `Syntax`
- Updated categories to valid repository categories

## Updated resource

- Name: Screenshot to Code
- URL: https://screenshottocode.net/
- Description: Tool for converting screenshots and UI mockups into frontend code to accelerate prototyping workflows.
- Categories: AI, Programming
- Keywords: screenshot, ui, frontend, prototyping, react, tailwind

## Checklist

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is highly or exclusively related to **programming** and **development**
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] I have searched the repository for any relevant issues or pull requests