### PR TITLE
Add PostalCodes.info resource

### DIFF
--- a/resources/p.ts
+++ b/resources/p.ts
@@ -257,6 +257,14 @@ export const resources: Resource[] = [
         url: 'https://polypane.app/',
     },
     {
+        name: 'PostalCodes.info',
+        description:
+            'Global postal code dataset and API for developers, with country coverage, downloadable CSV/JSON data, API documentation, and a citable Zenodo release.',
+        categories: ['API Building', 'Database', 'Open Source'],
+        url: 'https://postalcodes.info/api',
+        keywords: ['postal codes', 'postcodes', 'zip codes', 'geocoding', 'datasets', 'address validation'],
+    },
+    {
         name: 'PostgreSQL',
         description:
             'PostgreSQL is an enterprise-class open source database management system. It supports both SQL for relational and JSON for non-relational queries.',


### PR DESCRIPTION
Adds PostalCodes.info as a developer-facing postal-code API and dataset resource.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] I have searched the repository for any relevant issues or pull requests