### PR TITLE
Add NotaSalud resource

### DIFF
--- a/resources/n.ts
+++ b/resources/n.ts
@@ -155,7 +155,7 @@ export const resources: Resource[] = [
     {
         name: 'NotaSalud',
         description:
-            'Spanish ICD-10 and ICD-11 search reference with a public JSON API and embeddable CIE-10 widget for healthcare tools.',
+            'Spanish ICD/CIE search reference with a public CIE-10 JSON search endpoint and embeddable CIE-10 widget for healthcare tools.',
         categories: ['API Building', 'Documentation', 'Tooling'],
         url: 'https://notasalud.com/api-cie-10',
         keywords: ['icd', 'cie', 'healthcare', 'medical coding', 'spanish', 'api'],

--- a/resources/n.ts
+++ b/resources/n.ts
@@ -153,6 +153,14 @@ export const resources: Resource[] = [
         ],
     },
     {
+        name: 'NotaSalud',
+        description:
+            'Spanish ICD-10 and ICD-11 search reference with a public JSON API and embeddable CIE-10 widget for healthcare tools.',
+        categories: ['API Building', 'Documentation', 'Tooling'],
+        url: 'https://notasalud.com/api-cie-10',
+        keywords: ['icd', 'cie', 'healthcare', 'medical coding', 'spanish', 'api'],
+    },
+    {
         name: 'Notepad++',
         description:
             'Notepad++ is a text and source code editor for use with Microsoft Windows. It supports tabbed editing, which allows working with multiple open files in a single window.',


### PR DESCRIPTION
## Summary
Add NotaSalud as a developer resource for Spanish CIE-10 code search, public JSON API usage, and embeddable CIE-10 widget integration.

## Checklist
- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is highly related to programming and development through its public JSON API and embeddable widget
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] I have searched the repository for relevant issues or pull requests

Verified endpoint example: https://notasalud.com/buscar/cie-10?q=diabetes&limit=3. Access-Control-Allow-Origin was not observed, so CORS should be treated as No/Unknown.

Note: I ran `node scripts/validate-resources.js`; it reports two pre-existing alphabetical-order errors for NexTool/Nextradar and Octotree/OrcaSheets that are unrelated to this submission.
