### PR TITLE
Add CatchDoms

### DIFF
--- a/resources/c.ts
+++ b/resources/c.ts
@@ -77,6 +77,24 @@ export const resources: Resource[] = [
         url: 'https://catalog.thesys.dev/',
     },
     {
+        name: 'CatchDoms',
+        description:
+            'Expired and auction domain finder aggregating 100k+ domains from 17 marketplaces, enriched with SEO metrics (Trust Flow, backlinks, age, historical tech stack). Ships a public REST API and an open-source MCP server so AI assistants like Claude can query the catalog in natural language.',
+        categories: ['Domain', 'SEO', 'AI'],
+        url: 'https://catchdoms.com',
+        keywords: [
+            'expired-domains',
+            'domain-finder',
+            'seo',
+            'backlinks',
+            'trust-flow',
+            'mcp',
+            'api',
+            'wayback',
+            'domainer',
+        ],
+    },
+    {
         name: 'Cert Decoder',
         description:
             'Cert Decoder is a free online tool for decoding X.509 SSL/TLS certificates in PEM format directly in your browser.',


### PR DESCRIPTION
Adds CatchDoms — an expired domain finder with a public REST API and an open-source MCP server for AI assistants.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] I have searched the repository for any relevant issues or pull requests