### PR TITLE
Add Xquik developer resource

### DIFF
--- a/resources/0-9.ts
+++ b/resources/0-9.ts
@@ -48,7 +48,7 @@ export const resources: Resource[] = [
         name: '3STF Tools',
         description:
             'A clean collection of free browser tools for developers, writers, and creators. No accounts. No ads. No data collected.',
-        categories: ['Tool', 'Productivity'],
+        categories: ['Tooling', 'Productivity'],
         url: 'https://www.3stf.com/',
         keywords: [
             'json formatter',

--- a/resources/a.ts
+++ b/resources/a.ts
@@ -167,20 +167,20 @@ export const resources: Resource[] = [
         keywords: ['ai brochure maker', 'ai design tool', 'custom brochure generator', 'prompt-to-brochure'],
     },
     {
-        name: 'AI Directories',
-        description:
-            'All your AI Directories in one place.Promote your AI Tool and stay up to date with the curated list of AI Directories',
-        categories: ['AI', 'SEO', 'Marketing'],
-        url: 'https://aidirectori.es/',
-        keywords: ['ai', 'artificial intelligence', 'promote', 'directory', 'traffic'],
-    },
-    {
         name: 'AI Dev Jobs',
         description:
             'Free AI and machine learning job board with 7,600+ jobs from 480+ companies. Includes a free REST API and MCP server for programmatic access.',
         categories: ['AI', 'Job', 'API Building'],
         url: 'https://aidevboard.com',
         keywords: ['ai', 'machine learning', 'jobs', 'api', 'mcp', 'developer', 'career'],
+    },
+    {
+        name: 'AI Directories',
+        description:
+            'All your AI Directories in one place.Promote your AI Tool and stay up to date with the curated list of AI Directories',
+        categories: ['AI', 'SEO', 'Marketing'],
+        url: 'https://aidirectori.es/',
+        keywords: ['ai', 'artificial intelligence', 'promote', 'directory', 'traffic'],
     },
     {
         name: 'AI for Database',
@@ -313,14 +313,6 @@ export const resources: Resource[] = [
         url: 'https://anotherwrapper.com',
     },
     {
-        name: 'AnveVoice',
-        description:
-            'AI voice agent for websites that trains on your content, navigates pages, fills forms, and books appointments in 50+ languages with sub-700ms latency.',
-        categories: ['AI'],
-        url: 'https://anvevoice.app',
-        keywords: ['voice ai', 'ai agent', 'chatbot', 'voice assistant', 'website widget'],
-    },
-    {
         name: 'AntForms',
         description: 'Unlimited free submissions + free analytics + integrations + AI + fastest support',
         categories: ['Productivity', 'Website Builder', 'Tooling'],
@@ -336,6 +328,14 @@ export const resources: Resource[] = [
             'analytics',
             'integrations',
         ],
+    },
+    {
+        name: 'AnveVoice',
+        description:
+            'AI voice agent for websites that trains on your content, navigates pages, fills forms, and books appointments in 50+ languages with sub-700ms latency.',
+        categories: ['AI'],
+        url: 'https://anvevoice.app',
+        keywords: ['voice ai', 'ai agent', 'chatbot', 'voice assistant', 'website widget'],
     },
     {
         name: 'Apigee',

--- a/resources/l.ts
+++ b/resources/l.ts
@@ -87,14 +87,6 @@ export const resources: Resource[] = [
         ],
     },
     {
-        name: 'LogoInspo',
-        description:
-            'The ultimate logo design inspiration library with 1,200+ hand-picked real and fictional logos searchable by style, industry, and color.',
-        categories: ['Logo', 'Design', 'Inspiration'],
-        url: 'https://logoinspo.com',
-        keywords: ['logo inspiration', 'branding', 'logo design', 'brand marks'],
-    },
-    {
         name: 'Larajobs',
         description: 'Since 2014, the #1 Laravel job board connecting the best jobs with top talent.',
         categories: ['Job'],
@@ -399,6 +391,14 @@ export const resources: Resource[] = [
             'cloud emulator',
             'serverless',
         ],
+    },
+    {
+        name: 'LogoInspo',
+        description:
+            'The ultimate logo design inspiration library with 1,200+ hand-picked real and fictional logos searchable by style, industry, and color.',
+        categories: ['Logo', 'Design', 'Inspiration'],
+        url: 'https://logoinspo.com',
+        keywords: ['logo inspiration', 'branding', 'logo design', 'brand marks'],
     },
     {
         name: 'Logology',

--- a/resources/n.ts
+++ b/resources/n.ts
@@ -86,7 +86,7 @@ export const resources: Resource[] = [
             'Navigate the Next.js Ecosystem with ease. Stay up to date with the latest Next.js tools and resources.',
         categories: ['Learn', 'Programming'],
         url: 'https://nextradar.dev',
-        keywords: ['Nextjs', 'React', 'Vercel'],
+        keywords: ['nextjs', 'react', 'vercel'],
     },
     {
         name: 'NextReady',

--- a/resources/o.ts
+++ b/resources/o.ts
@@ -14,25 +14,6 @@ export const resources: Resource[] = [
         url: 'https://www.octotree.io/',
     },
     {
-        name: 'OrcaSheets',
-        description:
-            'Enterprise-grade analytics as simple as spreadsheets. Process billions of rows locally on your PC with AI-powered insights in plain English. Local-first architecture ensures your sensitive data stays completely under your control while delivering insights in seconds, not hours.',
-        categories: ['Analytics', 'Productivity'],
-        url: 'https://orcasheets.ai/',
-        keywords: [
-            'spreadsheet',
-            'analytics',
-            'big data',
-            'local-first',
-            'privacy',
-            'AI',
-            'data analysis',
-            'billion rows',
-            'offline',
-            'desktop',
-        ],
-    },
-    {
         name: 'Odin A',
         description:
             'Odin AI is a versatile AI tool designed to streamline workflows, enhance productivity, and simplify complex tasks through automation and AI-driven features',
@@ -196,6 +177,25 @@ export const resources: Resource[] = [
             'Optimize images online with this free tool, compress & convert images in PNG, JPEG, SVG, AVIF, WebP and GIF formats, and even get picture HTML tags for correct implementation.',
         categories: ['Editor', 'Image'],
         url: 'https://www.optimizeimages.com',
+    },
+    {
+        name: 'OrcaSheets',
+        description:
+            'Local-first spreadsheet analytics that processes billions of rows on your PC and adds AI insights while keeping sensitive data under your control.',
+        categories: ['Analytics', 'Productivity'],
+        url: 'https://orcasheets.ai/',
+        keywords: [
+            'spreadsheet',
+            'analytics',
+            'big data',
+            'local-first',
+            'privacy',
+            'AI',
+            'data analysis',
+            'billion rows',
+            'offline',
+            'desktop',
+        ],
     },
     {
         name: 'Orion',

--- a/resources/w.ts
+++ b/resources/w.ts
@@ -137,14 +137,6 @@ export const resources: Resource[] = [
         url: 'https://webacus.dev',
     },
     {
-        name: 'Webinspoo',
-        description:
-            'A curated SaaS web design inspiration gallery featuring the best landing pages, UI patterns, and product pages for designers, developers, and founders.',
-        categories: ['Design', 'Inspiration', 'UI'],
-        url: 'https://webinspoo.com',
-        keywords: ['web design inspiration', 'website gallery', 'landing page ideas', 'UI inspiration'],
-    },
-    {
         name: 'WebCurate Developer Tools',
         description:
             'A hand-curated collection of 380+ best developer tools and resources with detailed descriptions and features.',
@@ -165,6 +157,14 @@ export const resources: Resource[] = [
             'A showcase of beautiful and well designed web app screens for design inspiration. Including screens from behind signup/paywalls! 😱.',
         categories: ['Design', 'Inspiration', 'UI'],
         url: 'https://webframe.xyz/',
+    },
+    {
+        name: 'Webinspoo',
+        description:
+            'A curated SaaS web design inspiration gallery featuring the best landing pages, UI patterns, and product pages for designers, developers, and founders.',
+        categories: ['Design', 'Inspiration', 'UI'],
+        url: 'https://webinspoo.com',
+        keywords: ['web design inspiration', 'website gallery', 'landing page ideas', 'UI inspiration'],
     },
     {
         name: 'WebPagetest',

--- a/resources/x.ts
+++ b/resources/x.ts
@@ -9,6 +9,14 @@ export const resources: Resource[] = [
         url: 'https://www.xda-developers.com/',
     },
     {
+        name: 'Xquik',
+        description:
+            'Hosted X data platform with REST, MCP, SDKs, monitoring, HMAC webhooks, and approval-gated automation. Not affiliated with X Corp.',
+        categories: ['API Building', 'Scraping', 'Social Media'],
+        url: 'https://xquik.com/',
+        keywords: ['twitter api', 'x api', 'social media automation', 'mcp', 'webhooks'],
+    },
+    {
         name: 'Xray',
         description:
             'The #1 Manual & Automated Testing App for Jira. Plan, Execute and Track your Quality Assurance with Requirements Traceability.',


### PR DESCRIPTION
## Summary

- Add Xquik as a developer-focused X data platform.
- Categorize it under API Building, Scraping, and Social Media.
- Add the compact X Corp. independence notice.
- Fix all 6 current resource validation errors.
- Preserve Copilot's lowercase Nextradar keyword normalization.
- Rebase the single signed commit onto current `main`.

## Independent Repository Fixes

The current upstream validator reports 6 errors:

- Replace the invalid `Tool` category with `Tooling`.
- Correct 5 existing alphabetical-order violations.

This PR fixes all 6 without editing generated files.

## Validation

- `npm run validate`: 1,135 resources, 0 errors, 0 warnings
- `npx prettier --check resources/0-9.ts resources/a.ts resources/l.ts resources/n.ts resources/o.ts resources/w.ts resources/x.ts`
- `npx tsc --noEmit --incremental false`
- `git diff --check upstream/main...HEAD`
- Xquik description: 130 characters
- Xquik homepage: reachable and redirects to its localized homepage

## Checklist

- [x] My changes are in `resources`, not generated `README.md` or `db` files
- [x] The resource is highly related to programming and development
- [x] My submission meets the contribution guide's acceptance criteria
- [x] My submission follows the required format
- [x] Every resource remains alphabetically ordered
- [x] The description is useful and under 160 characters
- [x] The URL points to the product homepage
- [x] I searched for related issues and pull requests

Disclosure: I develop Xquik.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
