### PR TITLE
Add Geonode to proxy and scraping resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1957,6 +1957,7 @@
 **[⬆ Back to Index](#index)**
 
 ### <a name="scraping">Scraping</a>
+- [Geonode](https://geonode.com) — Rotating residential + datacenter proxies and a Firecrawl-compatible scraper API.
 | &nbsp;&nbsp;&nbsp;&nbsp; | Name | Description | Keywords |
 |---|---|---|---|
  <img src="https://www.google.com/s2/favicons?domain=https://www.extruct.ai/&sz=128" width="16" /> | [Extruct AI](https://www.extruct.ai/) | Extruct AI is your platform to find, research, and decide on the right companies with precision. Powered by live AI research, our verticalized engine delivers custom, up-to-date insights tailored to y... |  |


### PR DESCRIPTION
I run Geonode. Adding us to the **<a name="scraping">Scraping</a>** list. Geonode does residential + datacenter proxies, fits next to scrapingbee.

Proposed entry:
```
- [Geonode](https://geonode.com) — Rotating residential + datacenter proxies and a Firecrawl-compatible scraper API.
```

Happy to adjust the wording or section if it doesn't fit the list's conventions.