### PR TITLE
Add ZPlatform.ai

### DIFF
--- a/resources/z.ts
+++ b/resources/z.ts
@@ -38,6 +38,21 @@ export const resources: Resource[] = [
         url: 'https://zety.com/',
     },
     {
+        name: 'ZPlatform.ai',
+        description:
+            'Directory of AI tools and software lifetime deals, each tested hands-on with a Buy, Wait, or Skip verdict, organized across categories like writing, SEO, design, and productivity.',
+        categories: ['AI', 'Tooling'],
+        url: 'https://zplatform.ai',
+        keywords: [
+            'ai tools',
+            'ai tools directory',
+            'software deals',
+            'lifetime deals',
+            'saas deals',
+            'ai tool reviews',
+        ],
+    },
+    {
         name: 'Zuzia.app',
         description: 'AI-powered server monitoring and task automation for Linux and VPS.',
         categories: ['Tooling', 'Performance', 'AI'],


### PR DESCRIPTION
Adds **ZPlatform.ai** to `resources/z.ts`.

It's a directory of AI tools and software lifetime deals, where each entry is tested hands-on and given a Buy / Wait / Skip verdict, organized by category (writing, SEO, design, productivity, etc.). Useful for devs evaluating which AI tools or deals are worth adopting.

- Added in alphabetical order (between `Zety` and `Zuzia.app`)
- Categories used: `AI`, `Tooling`
- Formatted with `prettier`
- Did not edit `README.md` or `/db` (auto-generated)
- Not a duplicate (no existing entry for this URL)