### PR TITLE
docs: add Hanzilla Jobs resource

### DIFF
--- a/resources/h.ts
+++ b/resources/h.ts
@@ -64,6 +64,14 @@ export const resources: Resource[] = [
         url: 'https://app.haikei.app',
     },
     {
+        name: 'Hanzilla Jobs',
+        description:
+            'Daily-updated Canadian student and recent-grad software engineering jobs board with internships, co-ops, new grad, junior, and entry-level developer roles.',
+        categories: ['Job', 'Programming'],
+        url: 'https://jobs.hanzilla.co/categories/software-engineering/',
+        keywords: ['canada', 'software engineering', 'internships', 'new grad', 'junior developer'],
+    },
+    {
         name: 'Happy Hues',
         description:
             'See color palette inspiration on a real example website. As you click on different palettes every color on this site updates to give you context of how that color could be used for your design or illustration projects.',


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the `Job` / `Programming` resources list.
- Uses the software-engineering deep link so the resource stays tightly aligned with this developer-focused collection.

Hanzilla Jobs is a free daily-updated Canadian student/recent-grad jobs board with internships, co-ops, new grad, junior, and entry-level developer roles.

## Test plan
- Ran `npm run validate -- --quiet`.
- The new `resources/h.ts` entry passes ordering/format validation.
- The command still reports 3 pre-existing ordering errors in unrelated files: `a.ts`, `n.ts`, and `o.ts`.
