### PR TITLE
Add PracHub

### DIFF
--- a/resources/p.ts
+++ b/resources/p.ts
@@ -293,6 +293,14 @@ export const resources: Resource[] = [
         keywords: ['cv', 'LaTeX'],
     },
     {
+        name: 'PracHub',
+        description:
+            'Practice 8,500+ real tech-interview questions from 400+ top companies — coding, SQL, ML, and system design — in an in-browser console with AI-assisted hints.',
+        categories: ['Interview', 'Learn', 'Code Challenge'],
+        url: 'https://prachub.com',
+        keywords: ['interview', 'coding interview', 'leetcode alternative', 'system design', 'sql', 'machine learning'],
+    },
+    {
         name: 'Prime',
         description: 'Ultimate UI Framework.',
         categories: ['UI'],


### PR DESCRIPTION
Adds **PracHub** to the resources list.

Closes #1146

PracHub is a tech-interview practice platform: 8,500+ real interview questions from 400+ companies with an in-browser console for coding, SQL, ML, and system-design practice. Placed alphabetically in `resources/p.ts` between `PPResume` and `Prime`. Categories: `Interview`, `Learn`, `Code Challenge`.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission is formatted according to the guidelines in the contributing guide (ran the repo's pinned Prettier 2.2.1)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] I have searched the repository for any relevant issues or pull requests (this closes #1146)