### PR TITLE
Add PDF Dark

### DIFF
--- a/resources/p.ts
+++ b/resources/p.ts
@@ -96,6 +96,14 @@ export const resources: Resource[] = [
         url: 'https://www.pcloudy.com/',
     },
     {
+        name: 'PDF Dark',
+        description:
+            'Convert any PDF to a real dark-mode file fully in your browser. Open-source WebAssembly pipeline preserves photo and chart colors. No upload, no signup, no ads, MIT-licensed.',
+        categories: ['Browser', 'Productivity', 'Open Source'],
+        url: 'https://pdfdark.org',
+        keywords: ['pdf', 'dark mode', 'webassembly', 'open source', 'browser tool', 'mit license'],
+    },
+    {
         name: 'pdforge',
         description:
             'The new way to generate PDF documents for your SaaS. Use our no-code PDF builder and our easy-to-use API to generate modern PDF reports at scale without relying on your development team.',


### PR DESCRIPTION
## Summary

Adds **PDF Dark** to `resources/p.ts` (alphabetical position between `pCloudy` and `pdforge`).

- **Name**: PDF Dark
- **URL**: https://pdfdark.org
- **Categories**: Browser, Productivity, Open Source
- **What it is**: open-source browser-based tool that converts any PDF into a real dark-mode file. The entire conversion runs client-side via WebAssembly — your file never leaves the browser. A saturation-based algorithm preserves photos and charts in their original colors. Output is a standard PDF (not a viewer toggle), so it stays dark on Kindle, iPad, Acrobat, anywhere.
- **License**: MIT, source on GitHub: https://github.com/1436941541/pdf-dark

## Why it belongs in dev-resources

- **Open source** + **WebAssembly** stack — same technical profile as other entries under Browser/Productivity categories.
- Useful for developers/researchers who read code-, paper-, or docs-heavy PDFs at night and want a permanent dark-mode file (not just a viewer toggle that resets per app).
- Sits naturally next to existing PDF/document tools in the list (Patterns.dev, pdforge, etc.).

## Checklist

- [x] Resource added to the alphabetically correct file (`resources/p.ts`)
- [x] Entry placed in alphabetical order (between `pCloudy` and `pdforge`)
- [x] Required fields filled: `name`, `description`, `categories` (max 3), `url`
- [x] URL begins with `https://`
- [x] No duplicate (searched README — no existing PDF Dark entry)
- [x] `npm run prettier:format` ran (file unchanged — already formatted)
- [x] `README.md` and `/db` not edited (auto-generated)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

