### PR TITLE
Add Kube-DC Cloud to resources

### DIFF
--- a/resources/k.ts
+++ b/resources/k.ts
@@ -102,4 +102,12 @@ export const resources: Resource[] = [
             'Tech & Development',
         ],
     },
+    {
+        name: 'Kube-DC Cloud',
+        description:
+            'A Kubernetes-native cloud platform to manage VMs, Kubernetes clusters, databases, and networks via manifests, AI assistants, or a real-time web console — all running in a fixed-price resource pool starting at €19/mo, hosted in Amsterdam.',
+        categories: ['Hosting', 'Cloud Computing'],
+        url: 'https://kube-dc.cloud/',
+        keywords: ['kubernetes', 'cloud hosting', 'kubevirt', 'vps', 'devops'],
+    },
 ]


### PR DESCRIPTION
Adds Kube-DC Cloud — a Kubernetes-native, fixed-price cloud hosting platform (VMs, K8s clusters, databases, networks) starting at €19/mo, hosted in Amsterdam.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] I have searched the repository for any relevant issues or pull requests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

