### PR TITLE
Add agent-qa

### DIFF
--- a/resources/a.ts
+++ b/resources/a.ts
@@ -101,6 +101,14 @@ export const resources: Resource[] = [
         keywords: ['data', 'ai security', 'agent security', 'llm security'],
     },
     {
+        name: 'agent-qa',
+        description:
+            'Self-improving QA agent for web and mobile apps with natural-language tests, run memory, UI-change adaptation, and regression detection before shipping.',
+        categories: ['AI', 'Testing', 'Tooling'],
+        url: 'https://github.com/vostride/agent-qa',
+        keywords: ['ai', 'testing', 'qa', 'web', 'mobile', 'regression testing', 'natural language tests'],
+    },
+    {
         name: 'Ahrefs',
         description:
             "You don't have to be an SEO pro to rank higher and get more traffic. Join Ahrefs – we're a powerful but easy to learn SEO toolset with a passionate community.",


### PR DESCRIPTION
## Summary
- Add agent-qa to the  catalog
- Categorize it under , , and 

## Checklist
- [x] My changes were made in the  folder, not in the auto-generated  file or  folder
- [x] The resource is highly related to programming and development
- [x] My submission is formatted according to the contributing guide
- [x] My submission is ordered alphabetically based on the resource 
- [x] My submission has a useful description
- [x] I have searched the repository for duplicates

## Checks
- 
- 
> dev-resources@1.0.0 validate
> node scripts/validate-resources.js


📊 Validation Results
──────────────────────────────────────────────────
Total files: 27
Total resources: 1112
Errors: 6
Warnings: 0

❌ Errors:
  [0-9.ts:47] Resource "3STF Tools": Invalid category "Tool"
    💡 Fix: Did you mean "Tooling"?
  [a.ts:161] Resource "AI Dev Jobs" should come before "AI Directories"
    💡 Fix: Move "AI Dev Jobs" before "AI Directories" to maintain alphabetical order
  [a.ts:307] Resource "AntForms" should come before "AnveVoice"
    💡 Fix: Move "AntForms" before "AnveVoice" to maintain alphabetical order
  [l.ts:97] Resource "Larajobs" should come before "LogoInspo"
    💡 Fix: Move "Larajobs" before "LogoInspo" to maintain alphabetical order
  [o.ts:35] Resource "Odin A" should come before "OrcaSheets"
    💡 Fix: Move "Odin A" before "OrcaSheets" to maintain alphabetical order
  [w.ts:139] Resource "WebCurate Developer Tools" should come before "Webinspoo"
    💡 Fix: Move "WebCurate Developer Tools" before "Webinspoo" to maintain alphabetical order currently reports 6 pre-existing catalog errors unrelated to this entry: invalid category in , plus ordering issues in , , , and . The new  entry is not flagged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

