### PR TITLE
Add AnswerLens resource

### DIFF
--- a/resources/a.ts
+++ b/resources/a.ts
@@ -289,6 +289,14 @@ export const resources: Resource[] = [
         url: 'https://anotherwrapper.com',
     },
     {
+        name: 'AnswerLens',
+        description:
+            'AnswerLens audits public B2B SaaS website evidence for AI search, checking pricing, proof, docs, trust pages, metadata, and llms.txt gaps against source-backed fixes.',
+        categories: ['AI', 'SEO', 'Marketing'],
+        url: 'https://app.sfdj.net',
+        keywords: ['ai search', 'seo audit', 'b2b saas', 'public evidence', 'llms.txt'],
+    },
+    {
         name: 'AnveVoice',
         description:
             'AI voice agent for websites that trains on your content, navigates pages, fills forms, and books appointments in 50+ languages with sub-700ms latency.',


### PR DESCRIPTION
Adds AnswerLens to the resources list.\n\nAnswerLens is a public B2B SaaS website evidence audit tool focused on AI search, SEO, docs, trust pages, metadata, and llms.txt source gaps. I am connected to AnswerLens, so this is a self-submission.\n\nChecklist:\n- [x] My changes were made in the resources folder, not in the auto-generated README.md file or db folder\n- [x] The resource is related to development-facing SaaS website evidence, docs, metadata, llms.txt, SEO, and AI search work\n- [x] My submission meets the What we accept criteria in the contributing guide\n- [x] My submission is formatted according to the guidelines in the contributing guide\n- [x] My submission is ordered alphabetically based on the resource name\n- [x] My submission has a useful description\n- [x] I have searched the repository for any relevant issues or pull requests\n\nVerification:\n- Searched existing README, PRs, and issues for AnswerLens/app.sfdj.net; no duplicates found.\n- https://app.sfdj.net and https://app.sfdj.net/llms.txt returned HTTP 200.\n- git diff --check passed.\n- npm run validate currently fails on existing upstream data issues unrelated to this change: 3STF Tools category Tool, existing order issues for AI Dev Jobs, AntForms, Larajobs, Odin A, and WebCurate Developer Tools.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

