### PR TITLE
Add UIZZE

### DIFF
--- a/resources/u.ts
+++ b/resources/u.ts
@@ -100,6 +100,14 @@ export const resources: Resource[] = [
         url: 'https://uiverse.io/',
     },
     {
+        name: 'UIZZE',
+        description:
+            'Fix AI UI slop before it ships with a free-to-browse Web and iOS reference catalog plus full-access research tools for coding agents.',
+        categories: ['AI', 'Design', 'UI'],
+        url: 'https://uizze.com',
+        keywords: ['ai agents', 'coding agents', 'ui reference', 'web ui', 'ios ui', 'mcp', 'anti-slop'],
+    },
+    {
         name: 'Ultimate Web Speed',
         description:
             'Improve your website performance and SEO in hours not days. Use our tools and compare features, ease of use, and compatibility of resources.',


### PR DESCRIPTION
## Resource being added

**Name**: UIZZE  
**URL**: https://uizze.com  
**Categories**: AI, Design, UI

## Why it belongs here

UIZZE is a developer-facing UI reference platform for coding agents. Developers can browse Web and iOS UI references free, while full-access research tools support coding-agent workflows. It is the main product, is available now on its own domain, and paid products are explicitly accepted by this directory.

## Validation

- `https://uizze.com` returns HTTP 200.
- Repository and issue/PR searches found no existing UIZZE or `uizze.com` submission.
- `npx prettier --check resources/u.ts` passes.
- The proposed entry introduces no validator errors or warnings.
- Full-repository validation still reports six pre-existing errors on `main`; none concern UIZZE or `resources/u.ts`.
- `git diff --check` passes, and `resources/u.ts` is the only changed file.

# Pull Request Template

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] I have searched the repository for any relevant issues or pull requests


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

