### PR TITLE
Add Agent Island

### DIFF
--- a/resources/a.ts
+++ b/resources/a.ts
@@ -94,6 +94,14 @@ export const resources: Resource[] = [
         keywords: ['ftp', 'sftp', 'webdav', 's3', 'file transfer', 'cloud storage', 'encryption', 'tauri', 'rust'],
     },
     {
+        name: 'Agent Island',
+        description:
+            'Open-source local status companion for Claude Code and Codex sessions on macOS and Windows, with working, your-turn, stalled and attention states.',
+        categories: ['Open Source', 'Productivity', 'Tooling'],
+        url: 'https://agent-island.dev/',
+        keywords: ['claude code', 'codex', 'coding agents', 'session monitoring', 'developer tools'],
+    },
+    {
         name: 'Agent Security',
         description: 'Security for AI agents',
         categories: ['Security', 'AI', 'Newsletter'],


### PR DESCRIPTION
## Summary

Adds Agent Island as an open-source developer tool for monitoring local Claude Code and Codex session state on macOS and Windows.

- [x] The change is in `resources/a.ts`, not generated files
- [x] The product is for software developers
- [x] The product is available at its custom domain
- [x] The entry is alphabetically ordered and uses existing categories
- [x] The repository and open PRs were searched for duplicates

Validation: `npm run validate` still reports six pre-existing repository errors; none references the Agent Island entry.

Disclosure: I help run Agent Island.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

