### PR TITLE
Add Tura local open-source coding agent

### DIFF
--- a/resources/t.ts
+++ b/resources/t.ts
@@ -523,7 +523,7 @@ export const resources: Resource[] = [
     {
         name: 'Tura',
         description:
-            'Local-first open-source coding agent with CLI, TUI and GUI interfaces, project rules, checkpoints, built-in verification and public benchmarks.',
+            'Tura is a local, open-source coding agent for developers tired of vague claims, evidence-free token-saving tools, and agents that edit before understanding.',
         categories: ['AI', 'Programming', 'Terminal'],
         url: 'https://turaai.net/',
         keywords: ['coding agent', 'developer tool', 'rust', 'cli', 'tui', 'open source'],

--- a/resources/t.ts
+++ b/resources/t.ts
@@ -521,6 +521,14 @@ export const resources: Resource[] = [
         keywords: ['developer tool', 'email validation', 'sales prospecting', 'email deliverability'],
     },
     {
+        name: 'Tura',
+        description:
+            'Local-first open-source coding agent with CLI, TUI and GUI interfaces, project rules, checkpoints, built-in verification and public benchmarks.',
+        categories: ['AI', 'Programming', 'Terminal'],
+        url: 'https://turaai.net/',
+        keywords: ['coding agent', 'developer tool', 'rust', 'cli', 'tui', 'open source'],
+    },
+    {
         name: 'Tweet Detective',
         description:
             'Discover the power of AI detection on Twitter. Our tool uses advanced algorithms to analyze and reveal AI-generated content',


### PR DESCRIPTION
## Tura: 16.7% better performance, 77.5% fewer rounds.

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.

This PR adds [Tura](https://turaai.net/) to the AI, Programming, and Terminal categories. The resource field uses a faithful 156-character compression of the root README positioning because the contribution guide requires descriptions under 160 characters.

- Project: https://github.com/Tura-AI/tura
- Public benchmark: https://turaai.net/benchmark

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] I have searched the repository for any relevant issues or pull requests

### Validation

- `npx prettier --check resources/t.ts` passes.
- `git diff --check` passes.
- `npm run validate` reports six pre-existing errors in other resource files; it reports no error for the Tura entry.

Disclosure: I am affiliated with the Tura project.

AI-assistance disclosure: AI assistance was used to prepare and verify this submission; I reviewed the repository rules, source diff, validation output, and final wording.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->