### PR TITLE
Add Markstream

### DIFF
--- a/resources/m.ts
+++ b/resources/m.ts
@@ -118,6 +118,14 @@ export const resources: Resource[] = [
         url: 'https://markodenic.com/',
     },
     {
+        name: 'Markstream',
+        description:
+            'Streaming Markdown renderers for AI chat interfaces across Vue, React, Svelte, Angular, Nuxt, and Next.js, with diagrams, math, code, and safe HTML.',
+        categories: ['Library', 'Open Source', 'UI'],
+        url: 'https://markstream.simonhe.me/',
+        keywords: ['streaming markdown', 'ai chat', 'frontend', 'vue', 'react', 'svelte', 'angular'],
+    },
+    {
         name: 'Mastery Games',
         description:
             'Learn frontend development through play, repetition, and sleep. Each game builds up your skills from the ground up using the educational process of scaffolding. You learn one new concept at a time, and leverage spaced repetition to solidify each concept.',


### PR DESCRIPTION
## Resource

Adds [Markstream](https://markstream.simonhe.me/), an open-source streaming Markdown renderer family for developers building AI chat interfaces. It provides packages for Vue, React, Svelte, Angular, Nuxt, Next.js, and Vue 2.

## Checklist

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is highly related to programming and development
- [x] The submission meets the contributing guide criteria: main product, custom domain, clean URL, publicly available, and production-ready
- [x] The submission follows the documented TypeScript format
- [x] The entry is ordered alphabetically by resource name
- [x] The description is concise and useful
- [x] I searched the repository, issues, and pull requests for duplicates

## Validation

- `npx prettier --check resources/m.ts` passes.
- `npm run validate` reports no error for Markstream or `resources/m.ts`; it currently reports six pre-existing errors in other resource files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

