### PR TITLE
Add Nutilz to Productivity resources

### DIFF
--- a/resources/n.ts
+++ b/resources/n.ts
@@ -190,4 +190,12 @@ export const resources: Resource[] = [
         url: 'https://novoresume.com/',
         keywords: ['professional resume builder'],
     },
+    {
+        name: 'Nutilz',
+        description:
+            'Free online tools for developers and everyday tasks: calculators, text and image utilities, JSON/CSV converters, password generators, and more. No signup required.',
+        categories: ['Productivity', 'Tooling'],
+        url: 'https://nutilz.com',
+        keywords: ['free tools', 'calculators', 'json formatter', 'image converter', 'developer tools', 'text tools'],
+    },
 ]


### PR DESCRIPTION
Adds [Nutilz](https://nutilz.com) — a free online tools site (calculators, text/image utilities, JSON/CSV converters, password generators, and more), no signup required. Added alphabetically to `resources/n.ts` under the Productivity and Tooling categories, following CONTRIBUTING.md guidelines.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

