### PR TITLE
Add Apstal - AI-first web analytics tool

### DIFF
--- a/resources/a.ts
+++ b/resources/a.ts
@@ -381,6 +381,14 @@ export const resources: Resource[] = [
         url: 'https://appwrite.io/',
     },
     {
+        name: 'Apstal',
+        description:
+            'AI-first web analytics with session replay, heatmaps, and conversational AI queries. Free tier available.',
+        categories: ['Analytics', 'AI'],
+        url: 'https://apstal.com',
+        keywords: ['web analytics', 'session replay', 'heatmaps', 'ai analytics', 'privacy analytics'],
+    },
+    {
         name: 'Aptabase',
         description:
             'Open Source, Privacy-First and Simple Analytics for Mobile, Desktop and Web apps. Get simple and actionable insights without compromising user privacy.',


### PR DESCRIPTION
Adds [Apstal](https://apstal.com) to the Analytics category.

Apstal is an AI-first web analytics platform with session replay, heatmaps, and conversational AI queries. Free tier available.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

