### PR TITLE
Add Base Converter

### DIFF
--- a/resources/b.ts
+++ b/resources/b.ts
@@ -45,6 +45,14 @@ export const resources: Resource[] = [
         ],
     },
     {
+        name: 'Base Converter',
+        description:
+            'Convert numbers between binary, octal, decimal and hexadecimal instantly, with input validation and prefix support. 100% client-side, no signup required.',
+        categories: ['Programming', 'Tooling'],
+        url: 'https://nutilz.com/base-converter',
+        keywords: ['base converter', 'binary to decimal', 'hex converter', 'octal converter', 'number base conversion'],
+    },
+    {
         name: 'Bazzly',
         description: 'Get Customers From Reddit on Autopilot',
         categories: ['Marketing', 'AI', 'Social Media'],


### PR DESCRIPTION
Adds [Base Converter](https://nutilz.com/base-converter), a free browser-based number base converter (binary, octal, decimal, hexadecimal) with strict input validation and 0b/0o/0x prefix support. 100% client-side, no signup required.

- [x] Changes made in `resources` folder only
- [x] Highly related to programming/development
- [x] Meets the What we accept criteria (custom domain, main product, available now, no query params)
- [x] Formatted per contributing guide
- [x] Alphabetically ordered (between BandoFacile and Bazzly)
- [x] Useful description
- [x] Searched for existing/duplicate entries

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

