### PR TITLE
Add WealthVille

### DIFF
--- a/resources/w.ts
+++ b/resources/w.ts
@@ -96,6 +96,14 @@ export const resources: Resource[] = [
         url: 'https://weworkremotely.com/',
     },
     {
+        name: 'WealthVille',
+        description:
+            'Scores DeFi liquidity pools so you can tell whether one is worth providing liquidity to. Covers Solana and EVM pools, returning a 0-100 score and an Enter/Hold/Exit verdict, with a public track record that includes the misses. Free keyless REST API and an MCP server for AI agents.',
+        categories: ['Blockchain', 'Web3', 'Analytics'],
+        url: 'https://wealthville.net/developers',
+        keywords: ['DeFi', 'liquidity pools', 'Solana', 'EVM', 'API', 'MCP'],
+    },
+    {
         name: 'Web Code Tools',
         description:
             'Web Code Tools is a suite of code generators for HTML, CSS, Meta Tags, Open Graph, Structured Data, Twitter Cards and more.',

--- a/resources/w.ts
+++ b/resources/w.ts
@@ -99,7 +99,7 @@ export const resources: Resource[] = [
         name: 'WealthVille',
         description:
             'Scores DeFi liquidity pools so you can tell whether one is worth providing liquidity to. Covers Solana and EVM pools, returning a 0-100 score and an Enter/Hold/Exit verdict, with a public track record that includes the misses. Free keyless REST API and an MCP server for AI agents.',
-        categories: ['Blockchain', 'Web3', 'Analytics'],
+        categories: ['Web3', 'Analytics'],
         url: 'https://wealthville.net/developers',
         keywords: ['DeFi', 'liquidity pools', 'Solana', 'EVM', 'API', 'MCP'],
     },


### PR DESCRIPTION
Adds one entry to `resources/w.ts`. I have not touched `README.md` or `/db` — noted that both are auto-generated.

**WealthVille** scores DeFi liquidity pools, so a developer building anything that touches LP positions can ask "is this pool worth entering?" and get a number plus a verdict rather than raw TVL and volume to interpret themselves.

- Covers ~68,800 Solana pools (Meteora, Orca, Raydium) and 575 EVM pools across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC.
- Returns a 0-100 score and an Enter/Hold/Exit/Reduce/Avoid verdict with confidence calibrated per protocol.
- `/track-record` publishes hit rates including the misses, so the signal can be evaluated before it's trusted.
- Free keyless REST API, plus an MCP server for AI agents.

Placed between `We Work Remotely` and `Web Code Tools` — the space in "We Work" sorts before "Wea". `npm run validate` reports the same 6 errors before and after this change, all pre-existing in other files (`0-9.ts`, `a.ts`, `l.ts`, `o.ts`, and an unrelated `w.ts` ordering issue); none references this entry.

Per the note in your public-apis CONTRIBUTING that the two directories overlap on purpose, I've also opened marcelscruz/public-apis#1039 — this listing is for the developer tool, that one is for the public API it exposes. Happy to drop either if you'd rather only one.

Disclosure: I maintain this project.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

