### PR TITLE
Add Payload Components

### DIFF
--- a/resources/p.ts
+++ b/resources/p.ts
@@ -89,6 +89,14 @@ export const resources: Resource[] = [
         keywords: ['cms', 'headless', 'typescript', 'react', 'mongodb', 'express', 'graphql', 'rest'],
     },
     {
+        name: 'Payload Components',
+        description:
+            'An MIT registry and CLI that installs typed Payload CMS blocks into Payload v3 and Next.js projects with automated collection, renderer, type, and admin import-map wiring.',
+        categories: ['CMS', 'Programming', 'Tooling'],
+        url: 'https://www.payload-components.xyz/',
+        keywords: ['payload cms', 'next.js', 'typescript', 'shadcn', 'component registry', 'open source'],
+    },
+    {
         name: 'pCloudy',
         description:
             'Continuous testing platform that helps to speed up the app testing by enabling end to end continuous testing for enterprises.',


### PR DESCRIPTION
dev-resources already lists Payload CMS as a CMS platform. Payload Components complements that entry at the implementation layer: it is an MIT registry and CLI that installs typed Payload blocks into Payload v3 + Next.js projects, including the collection, renderer, type, and admin import-map wiring.

This PR adds the resource in alphabetical order in resources/p.ts, using existing CMS, Programming, and Tooling categories plus discovery keywords. The generated README is intentionally left untouched, following the contribution guide.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

