### PR TITLE
Add Semaphore

### DIFF
--- a/resources/s.ts
+++ b/resources/s.ts
@@ -170,6 +170,14 @@ export const resources: Resource[] = [
         keywords: ['html5', 'ui', 'library', 'framework', 'javascript'],
     },
     {
+        name: 'Semaphore',
+        description:
+            'Turn images into ASCII and Braille art locally in the browser, with plain-text and PNG exports and no uploads, accounts, or analytics.',
+        categories: ['Image', 'Tooling', 'Open Source'],
+        url: 'https://semaphore.bobochang.cn',
+        keywords: ['image to ascii', 'ascii art', 'braille art', 'client-side', 'local-first', 'privacy'],
+    },
+    {
         name: 'SEO Blueprint',
         description: 'Cutting-edge SEO tactics that are actually ranking websites.',
         categories: ['SEO'],


### PR DESCRIPTION
Adds [Semaphore](https://semaphore.bobochang.cn), an open-source image-to-ASCII and Braille tool for developer-facing plain-text use cases such as terminals, READMEs, chats, and code comments. Conversion and export run locally in the browser with no uploads, accounts, or client-side analytics.

## Checklist

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] The URL points to the product's homepage (not a deep link, docs page or subdomain), where applicable
- [x] I have searched the repository for any relevant issues or pull requests

## Validation

- `npx prettier --check resources/s.ts` passes
- `git diff --check` passes
- `npm run validate` reports six pre-existing errors in other resource files; it reports no error for `resources/s.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

