### PR TITLE
Add All Tools Verse

### DIFF
--- a/resources/a.ts
+++ b/resources/a.ts
@@ -270,6 +270,14 @@ export const resources: Resource[] = [
         keywords: ['icons', 'svg icons', 'open source icons'],
     },
     {
+        name: 'All Tools Verse',
+        description:
+            'A searchable collection of 1,000+ free browser tools, with 97 developer utilities for JSON, CSV, SQL, regex, encoding, CSS, and APIs.',
+        categories: ['Tooling', 'Programming', 'Browser'],
+        url: 'https://alltoolsverse.com/',
+        keywords: ['developer tools', 'browser tools', 'json', 'csv', 'sql', 'regex', 'encoding', 'css', 'api utilities'],
+    },
+    {
         name: 'ally.js',
         description:
             'JavaScript library to help modern web applications with accessibility concerns by making accessibility simpler.',


### PR DESCRIPTION
## Summary

Adds [All Tools Verse](https://alltoolsverse.com/) as a developer resource under Tooling, Programming, and Browser.

All Tools Verse is a searchable collection of 1,000+ free browser tools, including a dedicated set of 97 developer utilities for JSON, CSV, SQL, regex, encoding, CSS, APIs, cron, and code conversion.

## Validation

- Confirmed the custom-domain homepage is live and available without signup.
- Confirmed the Developer category currently contains 97 tools.
- Tested the cURL to Python utility with its POST, JSON, and Bearer sample. It generated a valid `requests.post(...)` call with headers and a JSON body.
- Searched the repository and pull requests for the product name and domain. No duplicate was found.
- Added only `resources/a.ts`, in alphabetical order after All SVG Icons.
- Description is 133 characters and uses valid categories from `types/category.ts`.

## Checklist

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is highly related to programming and development
- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the contributing guide
- [x] My submission is ordered alphabetically based on the resource name
- [x] My submission has a useful description
- [x] The URL points to the product homepage
- [x] I searched the repository for relevant issues and pull requests

## Disclosure

I am the maker of All Tools Verse. This contribution was prepared with OpenAI Codex assistance and reviewed by me.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

