### PR TITLE
Add Cactal

### DIFF
--- a/resources/c.ts
+++ b/resources/c.ts
@@ -2,6 +2,14 @@ import { Resource } from 'types'
 
 export const resources: Resource[] = [
     {
+        name: 'Cactal',
+        description:
+            'Cactal is the website platform for AI agents. Connect Claude, Cursor, or your own agent and build, host, and operate production websites from one API.',
+        categories: ['Website Builder', 'AI', 'Tooling'],
+        url: 'https://cactal.ai',
+        keywords: ['AI agents', 'MCP', 'website builder', 'AI website builder', 'developer tools', 'headless CMS'],
+    },
+    {
         name: 'Cactro',
         description: 'India’s Fairest Technical Test | Trusted by 300+ Companies',
         categories: ['Job', 'Interview', 'Code Challenge'],


### PR DESCRIPTION
- [x] My changes were made in the resources folder, not in the auto-generated README.md file or db folder
- [x] The resource is highly or exclusively related to programming and development
- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My submission is ordered alphabetically based on the resource name
- [x] My submission has a useful description
- [x] The URL points to the product homepage
- [x] I have searched the repository for relevant issues and pull requests

Validation note: Prettier passes for resources/c.ts. The repository-wide validator reports two pre-existing ordering errors in resources/a.ts and resources/f.ts; this change introduces no validator errors.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

