### PR TITLE
Add LabEx to Learn Resources

### DIFF
--- a/resources/l.ts
+++ b/resources/l.ts
@@ -2,6 +2,14 @@ import { Resource } from 'types'
 
 export const resources: Resource[] = [
     {
+        name: 'LabEx',
+        description:
+            'Hands-on online learning platform for Linux, DevOps, cybersecurity, programming, data science, and more through interactive labs.',
+        categories: ['Learn', 'Programming'],
+        url: 'https://labex.io',
+        keywords: ['hands-on labs', 'linux', 'devops', 'cybersecurity', 'programming'],
+    },
+    {
         name: 'Lacuna',
         description:
             'AI music platform with a developer API: generate full songs with vocals and lyrics, or instrumentals, plus stem separation and mastering. Official TypeScript SDK, CLI, and MCP server on npm.',


### PR DESCRIPTION
I’m from LabEx, an online learning platform built around hands-on, browser-based labs.

This PR adds LabEx to the Learn and Programming categories. LabEx provides interactive learning resources for Linux, DevOps, cybersecurity, programming, data science, and related technical skills.

The entry was added to `resources/l.ts`, uses the main LabEx homepage, has a description under 160 characters, uses valid categories, and is positioned alphabetically before Lacuna.

- [x] My changes were made in the `resources` folder
- [x] The resource is related to programming and development
- [x] The submission follows the contributing guide
- [x] The resource uses valid categories and formatting
- [x] The entry is ordered alphabetically by name
- [x] The entry has a concise description
- [x] The URL points to the product homepage
- [x] I searched the repository for duplicates and related pull requests

If any part of the entry needs to be adjusted, please let me know. Thank you!


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

