### PR TITLE
Add ItsPaint

### DIFF
--- a/resources/i.ts
+++ b/resources/i.ts
@@ -286,4 +286,11 @@ export const resources: Resource[] = [
         categories: ['Icon'],
         url: 'https://www.isocons.app',
     },
+    {
+        name: 'ItsPaint',
+        description:
+            'Free, open-source native macOS paint app for marking up screenshots and bug reports, with numbered step badges, pixelate, and 8 export formats.',
+        categories: ['Screenshot', 'Image', 'Design'],
+        url: 'https://itspaintmac.com',
+    },
 ]


### PR DESCRIPTION
Adding ItsPaint to `resources/i.ts`, alphabetically after Isocons. I have not touched `README.md` or `/db`.

**On the "for developers" criterion**, since that is the one worth arguing rather than assuming: the reason I built this and the reason I use it daily is filing bugs. You paste a screenshot, drop auto-numbered step badges on the steps so the ticket reads 1-2-3, pixelate anything that should not be in a tracker like an API key or a customer name, then drag the image straight into GitHub or Slack. No save panel and nothing left on the Desktop. macOS Markup has neither step badges nor pixelate, which is why this exists.

The three categories are `Screenshot`, `Image` and `Design`, all of which exist in `types/category.ts`, and the description is 141 characters. Custom domain, no query parameters in the URL.

[Source](https://github.com/joshlin2201/itspaint): native macOS, Swift 6, MIT, no third-party dependencies, notarised, free on the Mac App Store, 2.9 MB. The drawing engine is a separate UI-free SwiftPM package with 290 tests, so it is also usable as a dependency if anyone wants raster operations without an editor around them.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

