### PR TITLE
Add Nutilz — free browser-based developer tools

### DIFF
--- a/resources/b.ts
+++ b/resources/b.ts
@@ -45,6 +45,14 @@ export const resources: Resource[] = [
         ],
     },
     {
+        name: 'Base Converter',
+        description:
+            'Convert numbers between binary, octal, decimal and hexadecimal instantly, with input validation and prefix support. 100% client-side, no signup required.',
+        categories: ['Programming', 'Tooling'],
+        url: 'https://nutilz.com/base-converter',
+        keywords: ['base converter', 'binary to decimal', 'hex converter', 'octal converter', 'number base conversion'],
+    },
+    {
         name: 'Bazzly',
         description: 'Get Customers From Reddit on Autopilot',
         categories: ['Marketing', 'AI', 'Social Media'],

--- a/resources/n.ts
+++ b/resources/n.ts
@@ -190,4 +190,13 @@ export const resources: Resource[] = [
         url: 'https://novoresume.com/',
         keywords: ['professional resume builder'],
     },
+    {
+        name: 'Nutilz',
+        description:
+            'Free browser-based developer tools including regex tester, JSON formatter, converters, and calculators. No sign-up required.',
+        categories: ['Tooling', 'Productivity', 'Code Generator'],
+        url: 'https://nutilz.com',
+        keywords: ['regex', 'json', 'developer tools', 'converters', 'calculators'],
+    },
 ]
+

--- a/resources/n.ts
+++ b/resources/n.ts
@@ -199,4 +199,3 @@ export const resources: Resource[] = [
         keywords: ['regex', 'json', 'developer tools', 'converters', 'calculators'],
     },
 ]
-


### PR DESCRIPTION
Nutilz (https://nutilz.com) offers 23+ free browser-based developer tools including regex tester, JSON formatter, unit converter, and calculators. All tools run completely client-side in-browser with no sign-up or tracking required.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

