### PR TITLE
Add Sitemap Partitioning for Large Sites

### DIFF
--- a/resources/s.ts
+++ b/resources/s.ts
@@ -422,6 +422,14 @@ export const resources: Resource[] = [
         url: 'https://www.siteinspire.com/',
     },
     {
+        name: 'Sitemap Partitioning for Large Sites',
+        description:
+            'Guide to stable sitemap cohorts, honest freshness, submission telemetry, and coverage reconciliation for large websites.',
+        categories: ['Learn', 'Programming', 'SEO'],
+        url: 'https://edilec.com/blog/proeng-11045/sitemap-partitioning-large-sites-coverage-diagnostics/',
+        keywords: ['xml sitemap', 'technical seo', 'sitemap index', 'index coverage', 'release engineering'],
+    },
+    {
         name: 'SiteSee',
         description: 'A curated gallery of beautiful, modern websites meant to inspire web developers and designers.',
         categories: ['Design', 'Inspiration', 'UI'],


### PR DESCRIPTION
This adds a developer-facing guide to designing and operating stable sitemap cohorts for large-site releases.

The guide covers URL inventory contracts, deterministic partitioning, truthful `lastmod`, atomic generation, submission telemetry, coverage reconciliation, and incident response. The direct article URL is used because the guide itself is the submitted learning resource.

Disclosure: This submission is from Edilec, the publisher of the linked guide.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is highly related to programming and development operations
- [x] The submission meets the contributing guide's acceptance criteria
- [x] The submission follows the required TypeScript resource format
- [x] The resource is ordered alphabetically by name
- [x] The description is useful and 120 characters long
- [x] The URL points directly to the submitted guide on its custom domain
- [x] I searched current resources, issues, and pull requests for duplicates

Validation:

- `npx prettier --check resources/s.ts` passes
- The added `s.ts` resource introduces no validation error or warning
- Full validation reports the same two pre-existing ordering errors on the base branch in `resources/a.ts` and `resources/f.ts`; this change does not touch either file
- The public guide returns HTTP 200


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/dev-resources/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

