### PR TITLE
Add Jobs in JavaScript

### DIFF
--- a/resources/j.ts
+++ b/resources/j.ts
@@ -97,6 +97,14 @@ export const resources: Resource[] = [
         url: 'https://joblist.app/',
     },
     {
+        name: 'Jobs in JavaScript',
+        description:
+            'Job board for the JavaScript ecosystem. Roles are sourced directly from company career pages and refreshed daily, with filters for TypeScript, React, Node.js and remote work.',
+        categories: ['Job'],
+        url: 'https://jobsinjs.com/',
+        keywords: ['javascript jobs', 'typescript jobs', 'node.js jobs', 'react jobs', 'remote jobs'],
+    },
+    {
         name: 'Jobspresso',
         description:
             'Jobspresso is the easiest way to find remote jobs and careers at interesting and innovative companies.',


### PR DESCRIPTION
Adds Jobs in JavaScript to the `Job` category.

It's a job board for the JavaScript ecosystem. Roles are sourced directly from company career pages and refreshed daily, with filters for TypeScript, React, Node.js and remote work. 

Free to browse, no account required.

-   [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
-   [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
-   [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
-   [x] My submission is ordered alphabetically based on the resource `name`
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] I have searched the repository for any relevant issues or pull requests
