### PR TITLE
Add Skills Board

### DIFF
--- a/resources/s.ts
+++ b/resources/s.ts
@@ -503,7 +503,16 @@ export const resources: Resource[] = [
             'A shared library for the AI skills a team recommends. Collect skills in one searchable place and let every teammate use them through GitHub source, an install command, a ZIP download, or an authenticated MCP endpoint. Free forever and open source.',
         categories: ['AI', 'Open Source'],
         url: 'https://www.skillsboard.sh',
-        keywords: ['ai skills', 'claude skills', 'agent skills', 'mcp', 'claude code', 'codex', 'cursor', 'team library'],
+        keywords: [
+            'ai skills',
+            'claude skills',
+            'agent skills',
+            'mcp',
+            'claude code',
+            'codex',
+            'cursor',
+            'team library',
+        ],
     },
     {
         name: 'SkimAI',

--- a/resources/s.ts
+++ b/resources/s.ts
@@ -498,6 +498,14 @@ export const resources: Resource[] = [
         url: 'https://www.sketch.com/',
     },
     {
+        name: 'Skills Board',
+        description:
+            'A shared library for the AI skills a team recommends. Collect skills in one searchable place and let every teammate use them through GitHub source, an install command, a ZIP download, or an authenticated MCP endpoint. Free forever and open source.',
+        categories: ['AI', 'Open Source'],
+        url: 'https://www.skillsboard.sh',
+        keywords: ['ai skills', 'claude skills', 'agent skills', 'mcp', 'claude code', 'codex', 'cursor', 'team library'],
+    },
+    {
         name: 'SkimAI',
         description: 'The ultimate AI copilot for your email inbox',
         categories: ['Email', 'AI', 'Startup'],


### PR DESCRIPTION
Adding Skills Board, a free and open source (MIT) shared library for the AI skills a development team recommends: teammates use them via GitHub source, an install command, a ZIP download, or an authenticated MCP endpoint. Categories: AI, Open Source. Entry added in `resources/s.ts`, alphabetically between Sketch and SkimAI.

Disclosure: I am the author of Skills Board.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
- [x] I have searched the repository for any relevant issues or pull requests