### PR TITLE
Add Live Tennis API

### DIFF
--- a/resources/l.ts
+++ b/resources/l.ts
@@ -380,6 +380,14 @@ export const resources: Resource[] = [
         ],
     },
     {
+        name: 'Live Tennis API',
+        description:
+            'Tennis data API with live scores (serving and break-point state), player rankings, fixtures, and match history; free keyed tier available.',
+        categories: ['Analytics', 'Tooling'],
+        url: 'https://livetennisapi.com',
+        keywords: ['tennis', 'live scores', 'sports data', 'rankings', 'fixtures', 'api'],
+    },
+    {
         name: 'Lobsters',
         description: 'Lobsters is a computing-focused community centered around link aggregation and discussion.',
         categories: ['Forum'],


### PR DESCRIPTION
Adds **Live Tennis API** to `resources/l.ts`, alphabetically ordered (between LITSLINK and Lobsters).

Live Tennis API is a tennis data API for developers: live scores with serving and break-point state, players with current ranking, fixtures, and (on paid tiers) completed-match history, point-by-point data, and H2H. The free tier is keyed (30 req/min, 100 req/day). HTTPS and CORS supported, Bearer API-key auth. Docs: https://docs.livetennisapi.com

Categories: `Analytics` + `Tooling` — no closer fit exists in the current category set; this follows the precedent of other market/sports-data APIs listed under Analytics (e.g. DepthFeed).

Disclosure: I run this API.

Checklist:
- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
- [x] I have searched the repository for any relevant issues or pull requests
