### PR TITLE
Add ArtboardLab (Illustrator .ai to SVG/PNG/PDF, image compression)

### DIFF
--- a/resources/a.ts
+++ b/resources/a.ts
@@ -424,6 +424,14 @@ export const resources: Resource[] = [
         keywords: ['kubernetes'],
     },
     {
+        name: 'ArtboardLab',
+        description:
+            'Free browser-based tools that convert Adobe Illustrator .ai files to SVG, PNG or PDF and compress images. Files are processed locally, never uploaded.',
+        categories: ['Design', 'Image', 'Tooling'],
+        url: 'https://artboardlab.com',
+        keywords: ['illustrator', 'ai to svg', 'svg', 'image compression', 'webassembly', 'converter'],
+    },
+    {
         name: 'Artify',
         description:
             'Artify is an online and easy-to-use design editor that features thousands of customizable illustrations and template packs.',


### PR DESCRIPTION
Adds one entry, ArtboardLab, to `resources/a.ts`, alphabetically between Aptakube and Artify. No other files or lines touched.

**Disclosure: I built ArtboardLab, so this is a self-submission.**

**What it is** — a set of free browser-based tools for preparing web assets. The main one opens Adobe Illustrator `.ai` files (`.ai` here is the Illustrator file extension, not generative AI) and exports them to SVG, PNG or PDF using pdf.js; the image tools convert and compress PNG/JPG/WebP/AVIF using the jSquash WebAssembly codecs (mozjpeg, oxipng, webp, avif). All processing happens client-side, so files are never uploaded to a server, and there is no account or paywall. 16 tools in total, with English and Korean versions.

**Why it fits** — `.ai` to SVG/PNG and PNG/JPG to WebP/AVIF are asset-preparation steps in front-end work. I checked for overlap before submitting: `grep -rin "artboard" resources/` returns nothing, and `grep -rin "illustrator" resources/` returns a single incidental hit inside a keywords string in `resources/d.ts` (a YouTube channel), so there is currently no `.ai` file converter in the list. Categories used are all existing ones from `types/category.ts`: Design, Image, Tooling.

One note on scope: the audience is designers and front-end developers preparing assets, and I checked the programming/development box on that basis. If you read that criterion more strictly, I'm happy to adjust the entry or close this.

Checklist:

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain)
- [x] I have searched the repository for any relevant issues or pull requests
