### PR TITLE
Add Prismix (AI status tracking, news, MCP server directory)

### DIFF
--- a/resources/p.ts
+++ b/resources/p.ts
@@ -358,6 +358,14 @@ export const resources: Resource[] = [
         url: 'https://www.primefaces.org/',
     },
     {
+        name: 'Prismix',
+        description:
+            'Real-time status for 75+ AI services, curated news from 70+ sources, and a directory of 500+ MCP servers. Free REST API for status data.',
+        categories: ['AI', 'Tooling'],
+        url: 'https://prismix.dev',
+        keywords: ['ai status', 'mcp servers', 'ai news', 'uptime monitoring', 'openai status', 'anthropic status'],
+    },
+    {
         name: 'Privacyboard',
         description: 'Privacyboard helps you comply with GDPR in minutes so you can focus on what',
         categories: ['Legal'],


### PR DESCRIPTION
Adds **Prismix** — a hub for AI service status, news, and MCP servers.

Real-time status tracking for 75+ AI services (OpenAI, Anthropic, Cursor, Groq and others),
curated news from 70+ sources, and a searchable directory of 500+ MCP servers.
It also exposes a free REST API for the status data.

Site: https://prismix.dev

---

Please ensure all items below are checked before creating a pull request:

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
- [x] I have searched the repository for any relevant issues or pull requests

Notes on the acceptance criteria:

- **For developers** — the audience is people building with AI APIs: it answers "is this provider down right now" and "which MCP server do I need".
- **Main product only** — `prismix.dev` is the product itself, not a feature of something larger.
- **Custom domain** — own domain, not a shared subdomain.
- **Clean URL** — no query parameters.
- **Available now** — live, no waitlist.
- Formatted with the project's Prettier config (`prettier@2.2.1`), so the diff is the 8 added lines only.
- Categories used are both from `types/category.ts` — no new category is introduced.
