### PR TITLE
Add Statable to Analytics

### DIFF
--- a/resources/s.ts
+++ b/resources/s.ts
@@ -825,6 +825,14 @@ export const resources: Resource[] = [
         url: 'https://startups.gallery/',
     },
     {
+        name: 'Statable',
+        description:
+            'Cookieless web analytics built and hosted in the European Union. Reports visitors, traffic sources, campaigns, goals and funnels without setting cookies or storing persistent identifiers, so there is no consent gate to configure. The tracking script ranges from 504 to 1,855 bytes compressed depending on which features a site enables, and the data is queryable through a documented REST API with an OpenAPI spec.',
+        categories: ['Analytics'],
+        url: 'https://statable.com',
+        keywords: ['web analytics', 'cookieless', 'privacy', 'eu hosted', 'api'],
+    },
+    {
         name: 'Stormkit',
         description:
             'Stormkit integrates perfectly with your git flow. It builds, deploys and scales your javascript apps seamlessly.',


### PR DESCRIPTION
Adds **Statable** to the Analytics category.

Statable is cookieless web analytics built and hosted in the European Union. It reports visitors, traffic sources, campaigns, goals and funnels without setting cookies or storing persistent identifiers, so there is no consent gate to configure. The tracking script ranges from 504 to 1,855 bytes compressed depending on which features a site enables, and the data is queryable through a documented REST API with a public OpenAPI spec.

Please ensure all items below are checked before creating a pull request:

-   [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
-   [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
-   [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
-   [x] My submission is ordered alphabetically based on the resource `name`
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] I have searched the repository for any relevant issues or pull requests
