### PR TITLE
Add FluentEDI

### DIFF
--- a/resources/f.ts
+++ b/resources/f.ts
@@ -212,6 +212,14 @@ export const resources: Resource[] = [
         keywords: ['tailwind', 'ui components', 'ui kits', 'icon'],
     },
     {
+        name: 'FluentEDI',
+        description:
+            'Deterministic tools for AI agents over HTTP and MCP, with no API key or signup. Parse, generate and validate X12 EDI (850, 856, 810, 997), compute GS1 and IBAN check digits, do timezone and delivery-window arithmetic, resolve cron schedules, repair malformed JSON with the line and column where it broke, verify Ed25519 signatures, and scan text for leaked credentials.',
+        categories: ['AI', 'Tooling', 'Programming'],
+        url: 'https://fluentedi.com',
+        keywords: ['edi', 'x12', 'ai agents', 'mcp', 'api', 'developer tools'],
+    },
+    {
         name: 'Fluid UI',
         description:
             'Free lifetime account. Simple to learn, quick to master. Design interactive prototypes for Android, iOS, web and desktop in minutes.',


### PR DESCRIPTION
Adds FluentEDI to `resources/f.ts`, alphabetically. README and `/db` left untouched since they are generated.

- Custom domain (`fluentedi.com`), clean URL, no query parameters
- Free, no signup, no key, no paid tier
- Main product

A free HTTP and MCP API of deterministic tools for AI agents — X12 EDI parsing and generation, GS1 and IBAN-class check digits, timezone and delivery-window arithmetic, cron, JSON repair with error localisation, canonical JSON, signature verification, secret scanning and link checking.

Per CONTRIBUTING, it also exposes a public API, so I have submitted it to public-apis as well (marcelscruz/public-apis#1145) — flagging that here rather than leaving it to look like a duplicate.