### PR TITLE
Add Chemistry AI resource

### DIFF
--- a/resources/c.ts
+++ b/resources/c.ts
@@ -234,7 +234,15 @@ export const resources: Resource[] = [
         categories: ['Design', 'UI'],
         url: 'https://www.checklist.design/',
     },
-    {
+        {
+        name: 'Chemistry AI',
+        description:
+            'AI chemistry tutor with step-by-step explanations for equations, stoichiometry, molarity, reactions, and study questions.',
+        categories: ['AI', 'Learn'],
+        url: 'https://chemistryai.chat/',
+        keywords: ['chemistry', 'education', 'AI tutor', 'stoichiometry', 'problem solver'],
+    },
+{
         name: 'Choc UI',
         description:
             'Choc UI is a set of accessible and reusable components that are commonly used in web applications.',


### PR DESCRIPTION
Add Chemistry AI as an AI-powered chemistry learning and problem-solving resource under the existing AI and Learn categories. Chemistry AI is primarily an educational web tool, so the programming/development-only criterion is intentionally left unchecked for transparent maintainer review.

# Pull Request Template

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [ ] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [ ] My submission meets every What we accept criterion in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the product homepage
- [x] I searched the repository for relevant issues, pull requests, and duplicate resources
