### PR TITLE
Add Site Punchlist

### DIFF
--- a/resources/s.ts
+++ b/resources/s.ts
@@ -418,6 +418,14 @@ export const resources: Resource[] = [
         ],
     },
     {
+        name: 'Site Punchlist',
+        description:
+            'Crawls a whole site with axe-core, groups repeated findings by the component causing them, and returns a prioritised fix list as HTML, PDF and CSV.',
+        categories: ['Accessibility', 'Testing', 'Tooling'],
+        url: 'https://sitepunchlist.com',
+        keywords: ['accessibility', 'a11y', 'wcag', 'axe-core', 'accessibility testing'],
+    },
+    {
         name: 'Site123',
         description:
             'Create a free website with SITE123. No design or coding skills required. SITE123 is by far the easiest free website builder. Create your website now!',
@@ -431,14 +439,6 @@ export const resources: Resource[] = [
             'A CSS gallery and showcase of the best web design inspiration, featuring over 2,500 websites searchable by type, subject, and style.',
         categories: ['Design', 'Inspiration', 'UI'],
         url: 'https://www.siteinspire.com/',
-    },
-    {
-        name: 'Site Punchlist',
-        description:
-            'Crawls a whole site with axe-core, groups repeated findings by the component causing them, and returns a prioritised fix list as HTML, PDF and CSV.',
-        categories: ['Accessibility', 'Testing', 'Tooling'],
-        url: 'https://sitepunchlist.com',
-        keywords: ['accessibility', 'a11y', 'wcag', 'axe-core', 'accessibility testing'],
     },
     {
         name: 'SiteSee',

--- a/resources/s.ts
+++ b/resources/s.ts
@@ -433,6 +433,14 @@ export const resources: Resource[] = [
         url: 'https://www.siteinspire.com/',
     },
     {
+        name: 'Site Punchlist',
+        description:
+            'Crawls a whole site with axe-core, groups repeated findings by the component causing them, and returns a prioritised fix list as HTML, PDF and CSV.',
+        categories: ['Accessibility', 'Testing', 'Tooling'],
+        url: 'https://sitepunchlist.com',
+        keywords: ['accessibility', 'a11y', 'wcag', 'axe-core', 'accessibility testing'],
+    },
+    {
         name: 'SiteSee',
         description: 'A curated gallery of beautiful, modern websites meant to inspire web developers and designers.',
         categories: ['Design', 'Inspiration', 'UI'],


### PR DESCRIPTION
Adds **Site Punchlist** to `resources/s.ts`, between `siteInspire` and `SiteSee`. Eight added lines, nothing else touched.

**Disclosure: I build this**, flagging it rather than leaving you to work it out.

A whole-site accessibility scanner. It crawls the site with axe-core, then groups repeated findings by the shared component that causes them — so a defect in one header reports once with the list of pages it affects, rather than once per page. A run that produced 2,898 raw violations resolved to 12 distinct problems. Output is a hosted report plus PDF and CSV.

Developers can try it with no account, no card and no email address — five pages free.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
- [x] I have searched the repository for any relevant issues or pull requests

Against **What we accept**, specifically: it is a developer tool rather than an end-user product; it is the main product, not a feature of a larger one; it is on its own custom domain; the URL carries no query parameters; and it is shipped and usable today with no waitlist. Description is 148 characters, inside the 160 cap. Three categories, the maximum allowed.