### PR TITLE
Add open-banking.io

### DIFF
--- a/resources/o.ts
+++ b/resources/o.ts
@@ -145,6 +145,14 @@ export const resources: Resource[] = [
         url: 'https://openvim.com/',
     },
     {
+        name: 'open-banking.io',
+        description:
+            'Unified REST API for European bank accounts. PSD2 open-banking data — connect to thousands of EU banks without your own banking certificates.',
+        categories: ['API Building'],
+        url: 'https://open-banking.io',
+        keywords: ['open banking', 'psd2', 'bank api', 'fintech', 'payments'],
+    },
+    {
         name: 'OpenChakra',
         description: 'React JSX visual editor for Chakra UI.',
         categories: ['Prototyping', 'UI'],


### PR DESCRIPTION
Adds **open-banking.io** — a unified REST API for European bank accounts. It gives developers PSD2 open-banking data (accounts, transactions, payments) across thousands of EU banks through one integration, without needing to obtain their own banking certificates.

- Entry added to `resources/o.ts` in alphabetical order, following the existing resource format (name, description, categories, url, keywords).

Disclosure: I maintain open-banking.io.
