### PR TITLE
Add XiuRouter

### DIFF
--- a/resources/x.ts
+++ b/resources/x.ts
@@ -9,6 +9,14 @@ export const resources: Resource[] = [
         url: 'https://www.xda-developers.com/',
     },
     {
+        name: 'XiuRouter',
+        description:
+            'One API for GPT, Claude, and Gemini with native protocol routes, scoped keys, usage records, and transparent usage-based pricing.',
+        categories: ['AI', 'API Building', 'Tooling'],
+        url: 'https://router.xiu.ai',
+        keywords: ['llm api', 'ai gateway', 'openai', 'anthropic', 'gemini', 'model routing'],
+    },
+    {
         name: 'Xquik',
         description:
             'Hosted X data platform with REST, MCP, SDKs, monitoring, HMAC webhooks, and approval-gated automation. Not affiliated with X Corp.',


### PR DESCRIPTION
Adds XiuRouter to `resources/x.ts` as an AI/API developer resource.

XiuRouter is the main product at `router.xiu.ai`: a production model API for developers and AI agents, with native OpenAI, Anthropic, and Gemini protocol routes, scoped API keys, usage records, and usage-based pricing. This is a self-submission on behalf of XiuLab Inc, which operates XiuAI and its products.

The change is limited to one alphabetically placed entry. The description is 129 characters and uses three existing categories.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the product homepage
- [x] I searched the repository for relevant issues and pull requests