### PR TITLE
Remove Juno

### DIFF
--- a/resources/j.ts
+++ b/resources/j.ts
@@ -132,14 +132,6 @@ export const resources: Resource[] = [
         keywords: ['JSON', 'JSON Schema'],
     },
     {
-        name: 'Juno',
-        description:
-            'Juno is an open-source serverless platform for hosting static websites, building web applications, and running serverless functions with the privacy and control of self-hosting.',
-        categories: ['Serverless', 'Productivity', 'Cloud Computing'],
-        url: 'https://juno.build/',
-        keywords: ['authentication', 'database', 'hosting', 'storage', 'analytics', 'serverless', 'development'],
-    },
-    {
         name: 'JustRemote',
         description:
             'Discover Remote Jobs from around the world. Give up the commute, work remotely and do what you love, daily, from anywhere. Find your perfect remote development, design, sales or marketing job today.',


### PR DESCRIPTION
My platform [Juno](https://juno.build) is deprecated. This PR removes its addition (#975) to the list of resources.
