### PR TITLE
Remove 5 hijacked and 8 dead listings

### DIFF
--- a/resources/a.ts
+++ b/resources/a.ts
@@ -154,13 +154,6 @@ export const resources: Resource[] = [
         keywords: ['ai', 'artificial intelligence', 'developer', 'ai agent', 'marketplace', 'store', 'news', 'blogs'],
     },
     {
-        name: 'AI Alternative',
-        description: 'Discover the best AI tools and their alternatives',
-        categories: ['AI', 'Tooling', 'Productivity'],
-        url: 'https://aialternative.co/',
-        keywords: ['ai directory', 'ai alternatives', 'ai tools directory', 'startup tools'],
-    },
-    {
         name: 'AI Best Tools',
         description: 'Discover the best AI tools in AIBest.tools',
         categories: ['AI', 'Tooling'],
@@ -218,13 +211,6 @@ export const resources: Resource[] = [
         categories: ['Marketing', 'Design', 'AI'],
         url: 'https://venngage.com/ai-tools/one-pager-generator',
         keywords: ['one pager generator', 'ai one pager generator', 'create one pager', 'one pager template'],
-    },
-    {
-        name: 'AI SEO Tools',
-        description: 'Discover the Best AI SEO Tools in One Place',
-        categories: ['Marketing', 'SEO', 'AI'],
-        url: 'https://www.ai-seo.tools',
-        keywords: ['automation', 'ai', 'marketing', 'aggregators'],
     },
     {
         name: 'AI-Text-Humanizer',

--- a/resources/b.ts
+++ b/resources/b.ts
@@ -456,22 +456,6 @@ export const resources: Resource[] = [
         url: 'https://www.browserstack.com/',
     },
     {
-        name: 'BuddAIr',
-        description: 'Unlock your AI companion now',
-        categories: ['AI', 'Productivity'],
-        url: 'https://buddair.com/',
-        keywords: [
-            'AI companion',
-            'virtual buddy',
-            'AI tools navigation',
-            'emotional support AI',
-            'find AI friend',
-            'best AI companion apps',
-            'personalized AI interactions',
-            'BuddAIr',
-        ],
-    },
-    {
         name: 'Build you SaaS',
         description:
             'Can you bootstrap a profitable startup in 2021? Thousands of entrepreneurs, developers, designers, and product people have tried to launch their own web apps. But with so many venture-backed startups now, is it still possible? Follow Jon and Justin as they build their podcasting SaaS, Transistor.fm.',

--- a/resources/e.ts
+++ b/resources/e.ts
@@ -153,12 +153,6 @@ export const resources: Resource[] = [
         url: 'https://elements.envato.com/',
     },
     {
-        name: 'Enveloop',
-        description: 'Design, host, and send emails and texts. All from one place - with a simple API.',
-        categories: ['Email', 'Design'],
-        url: 'https://enveloop.com/',
-    },
-    {
         name: 'Epic React',
         description: 'Strap in and take your React applications to the next level.',
         categories: ['Learn', 'Programming'],

--- a/resources/f.ts
+++ b/resources/f.ts
@@ -22,13 +22,6 @@ export const resources: Resource[] = [
         url: 'https://famewall.io/',
     },
     {
-        name: 'Fast Articles AI',
-        description:
-            'Fast Articles AI is an advanced AI writing tool for SEO. Generate perfect SEO articles and blog posts in seconds.',
-        categories: ['Marketing', 'SEO', 'Writing'],
-        url: 'https://fastarticles.ai/',
-    },
-    {
         name: 'Fathom',
         description:
             'Fathom Analytics is simple, GDPR + CCPA + PECR compliant website analytics tool, no cookie notice required. No tracking or storing personal data of your users.',

--- a/resources/g.ts
+++ b/resources/g.ts
@@ -148,13 +148,6 @@ export const resources: Resource[] = [
         keywords: ['git', 'cli', 'workflow', 'terminal', 'commit', 'golang'],
     },
     {
-        name: 'Gliesess 90 marketing strategy breakdowns',
-        description:
-            'Browse the most comprehensive list of online marketing strategies on the internet. Find the Social Media and Search Engine strategies of each company.',
-        categories: ['SEO', 'Learn', 'Marketing'],
-        url: 'https://www.gliesess.com/online-marketing-strategies',
-    },
-    {
         name: 'GoatCounter',
         description:
             'GoatCounter is an open source web analytics platform available as a hosted service (free for non-commercial use) or self-hosted app.',
@@ -245,22 +238,6 @@ export const resources: Resource[] = [
             'how to write a resume',
             'how to make a resume',
             'sample resumes',
-        ],
-    },
-    {
-        name: 'GPT4oMini',
-        description: 'GPT4oMini.app: Free GPT4oMini Access - Advanced AI Conversation Generator',
-        categories: ['AI'],
-        url: 'https://gpt4omini.app/',
-        keywords: [
-            'GPT4oMini',
-            'GPT4o',
-            'Free GPT-4',
-            'ChatGPT',
-            'ChatGPT4oMini',
-            'chatbot',
-            'Free ChatGPT Access',
-            'AI Conversation Generator',
         ],
     },
     {

--- a/resources/n.ts
+++ b/resources/n.ts
@@ -158,13 +158,6 @@ export const resources: Resource[] = [
         keywords: ['no-code', 'templates', 'webflow', 'framer', 'bubble'],
     },
     {
-        name: 'No-Code Scraper',
-        description: 'Seamlessly extract data from any website with just a few simple inputs.',
-        categories: ['Scraping', 'AI'],
-        url: 'https://www.nocodescraper.com',
-        keywords: ['scraper', 'no code', 'ai web scraper', 'web scraper', 'visual web scraper', 'web scraping'],
-    },
-    {
         name: 'Nomad List',
         description: 'Best places to live for a digital nomad',
         categories: ['Job', 'Job', 'Remote'],

--- a/resources/o.ts
+++ b/resources/o.ts
@@ -36,13 +36,6 @@ export const resources: Resource[] = [
         url: 'https://www.offen.dev/',
     },
     {
-        name: 'OkJob',
-        description: '4 day Week Job Board',
-        categories: ['Job'],
-        url: 'https://okjob.io/',
-        keywords: ['Flexible work schedule', 'Work-life balance', 'Remote work options'],
-    },
-    {
         name: 'Omnara',
         description: 'Command Center for AI Coding Agents',
         categories: ['AI', 'Programming', 'Tooling'],

--- a/resources/p.ts
+++ b/resources/p.ts
@@ -381,13 +381,6 @@ export const resources: Resource[] = [
         keywords: ['ai status', 'mcp servers', 'ai news', 'uptime monitoring', 'openai status', 'anthropic status'],
     },
     {
-        name: 'Privacyboard',
-        description: 'Privacyboard helps you comply with GDPR in minutes so you can focus on what',
-        categories: ['Legal'],
-        url: 'https://www.privacyboard.co',
-        keywords: ['privacy', 'gdpr', 'compliance'],
-    },
-    {
         name: 'Product Hunt',
         description:
             'Product Hunt is a curation of the best new products, every day. Discover the latest mobile apps, websites, and technology products that everyone',

--- a/resources/r.ts
+++ b/resources/r.ts
@@ -430,13 +430,6 @@ export const resources: Resource[] = [
         url: 'https://github.com/antfu/retypewriter',
     },
     {
-        name: 'Revyou',
-        description: 'Turn your reviews into a lead magnet',
-        categories: ['AI', 'Marketing'],
-        url: 'https://www.revyou.me/',
-        keywords: ['ai', 'marketing', 'lead magnet', 'reviews'],
-    },
-    {
         name: 'Rider',
         description: 'Develop .NET, ASP.NET, .NET Core, Xamarin or Unity applications on Windows, Mac, Linux.',
         categories: ['Editor', 'Programming'],

--- a/resources/s.ts
+++ b/resources/s.ts
@@ -924,13 +924,6 @@ export const resources: Resource[] = [
         url: 'https://www.sublimetext.com/',
     },
     {
-        name: 'Summara',
-        description: 'YouTube AI Summary and Transcript widget',
-        categories: ['AI', 'Extension', 'Learn'],
-        url: 'https://summara.io/',
-        keywords: ['youtube ai summary', 'youtube summarizer', 'youtube transcript', 'youtube captions'],
-    },
-    {
         name: 'Supabase',
         description:
             'Create a backend in less than 2 minutes. Start your project with a Postgres Database, Authentication, instant APIs, and realtime subscriptions.',
@@ -942,13 +935,6 @@ export const resources: Resource[] = [
         description: 'An open-source UI component library inspired by Tailwind and AntDesign.',
         categories: ['Library', 'Programming', 'UI'],
         url: 'https://ui.supabase.io/',
-    },
-    {
-        name: 'Supaboost',
-        description:
-            'Supaboost is an all-in-one SaaS Starter Kit, aiming to provide developers with the right tools to save hours of setting up their new application. Supaboost comes readily available with user management, roles and access based on roles, billing/subscriptions, frontend layout and SQL statements to create your a new backend with security today..',
-        categories: ['Startup', 'Template'],
-        url: 'https://www.supaboost.dev',
     },
     {
         name: 'supastarter',


### PR DESCRIPTION
Five listed domains expired, were re-registered, and now serve content unrelated to what they were listed as. All five are live in the directory right now, so devresourc.es is currently sending visitors to them:

| Listing | Listed as | Now serves |
|---|---|---|
| AI Alternative | Discover the best AI tools and their alternatives | BATAK5D Indonesian slot/toto casino |
| OkJob | 4 day week job board | Vietnamese betting-odds site (kèo nhà cái) |
| Summara | summarisation tool | Indonesian togel/lottery predictions |
| Gliesess | 90 marketing strategy breakdowns | JS redirect into a malvertising tracker (anast-nch.com) |
| GPT4oMini | GPT-4o mini tool | unrelated academic site (Data Science in Libraries) |

None of these were ever reported by a user. They were found by re-checking every URL the deleted `[Bot] Broken Links Checker` had flagged.

Eight more listings are simply gone:

| Listing | Evidence |
|---|---|
| BuddAIr | 301s to snoeken.net, which no longer resolves |
| No-Code Scraper | no DNS record |
| Privacyboard | no DNS record |
| AI SEO Tools | Vercel `DEPLOYMENT_DISABLED` |
| Supaboost | Vercel `DEPLOYMENT_DISABLED` |
| Revyou | Vercel `DEPLOYMENT_PAUSED` |
| Fast Articles AI | parked, listed for sale |
| Enveloop | parked for sale on GoDaddy |

### Why the link checker missed the hijacks

A re-registered domain answers **200 OK at the listed URL**, so the weekly `check-links` sweep sees a healthy row. `redirectDrift` only fires when the landing domain differs from the listed one, and four of the five serve the new content at their own domain — so drift stays silent too. Detecting this needs a content check, not a status check.

Verified by live fetch on 2026-09-02. Merging lets the 06:00 `update-db` sync archive the corresponding rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)