### PR TITLE
Add Naratake

### DIFF
--- a/resources/n.ts
+++ b/resources/n.ts
@@ -21,6 +21,14 @@ export const resources: Resource[] = [
         keywords: ['domain name', 'dev tools', 'AI', 'CLI'],
     },
     {
+        name: 'Naratake',
+        description:
+            'Drag-and-drop website builder for local businesses. 111 components, 15 design styles, publishes a real Next.js app with full source-code export.',
+        categories: ['Website Builder', 'CMS', 'Template'],
+        url: 'https://naratake.com',
+        keywords: ['website builder', 'no-code', 'next.js', 'small business', 'source code export'],
+    },
+    {
         name: 'Narrow AI',
         description:
             'Automated Prompt Engineering and Optimization platform that can autonomously write, monitor, and optimize prompts for any model',


### PR DESCRIPTION
Adds Naratake under Website Builder / CMS / Template.

It is relevant to developers specifically because of the export path: a published site is an ordinary Next.js project — storefront, admin, REST API and Prisma schema — and the whole codebase can be exported and self-hosted. A public example of that output is here: https://github.com/ctingyi404-cloud/naratake-export-example

That puts it alongside Framer and Srcbook, which are already listed under Website Builder.

Edited resources/n.ts only (README.md and /db are generated), alphabetical between Namekit and Narrow AI, description under 160 characters, three categories, https URL with no query parameters.