### PR TITLE
Add OuterCheck (free website verification tool, no sign-up)

### DIFF
--- a/resources/o.ts
+++ b/resources/o.ts
@@ -56,14 +56,6 @@ export const resources: Resource[] = [
         url: 'https://one.com',
     },
     {
-        name: 'OuterCheck',
-        description:
-            'Free public API that verifies a website the way the outside web sees it: DNS, TLS, robots.txt, indexability and HTML checks with evidence-first JSON. No sign-up or key required.',
-        categories: ['Security', 'SEO', 'Tooling'],
-        url: 'https://outercheck.com/',
-        keywords: ['website verification', 'dns', 'tls', 'robots.txt', 'seo'],
-    },
-    {
         name: 'Onlime',
         description: 'Onlime is your secure cloud storage solution for what matters most.',
         categories: ['Productivity', 'Security', 'Startup'],
@@ -219,6 +211,14 @@ export const resources: Resource[] = [
         categories: ['Open Source', 'Analytics', 'Security'],
         url: 'https://osintresearcher.com/',
         keywords: ['gitHub', 'osint', 'open source', 'repo search'],
+    },
+    {
+        name: 'OuterCheck',
+        description:
+            'Free public API that verifies a website the way the outside web sees it: DNS, TLS, robots.txt, indexability and HTML checks with evidence-first JSON. No sign-up or key required.',
+        categories: ['Security', 'SEO', 'Tooling'],
+        url: 'https://outercheck.com/',
+        keywords: ['website verification', 'dns', 'tls', 'robots.txt', 'seo'],
     },
     {
         name: 'Outlier Kit',

--- a/resources/o.ts
+++ b/resources/o.ts
@@ -56,6 +56,14 @@ export const resources: Resource[] = [
         url: 'https://one.com',
     },
     {
+        name: 'OuterCheck',
+        description:
+            'Free public API that verifies a website the way the outside web sees it: DNS, TLS, robots.txt, indexability and HTML checks with evidence-first JSON. No sign-up or key required.',
+        categories: ['Security', 'SEO', 'Tooling'],
+        url: 'https://outercheck.com/',
+        keywords: ['website verification', 'dns', 'tls', 'robots.txt', 'seo'],
+    },
+    {
         name: 'Onlime',
         description: 'Onlime is your secure cloud storage solution for what matters most.',
         categories: ['Productivity', 'Security', 'Startup'],


### PR DESCRIPTION
Hi! I'm one of the maintainers of OuterCheck.

OuterCheck is a free tool + public API that verifies a website the way the outside web sees it: DNS, TLS, robots.txt, indexability and HTML checks, returning per-check verdicts with evidence. No sign-up, no key, HTTPS.

Placed alphabetically in o.ts with categories Security / SEO / Tooling. Happy to adjust anything.