### PR TITLE
Add AnyAPI

### DIFF
--- a/resources/a.ts
+++ b/resources/a.ts
@@ -325,6 +325,14 @@ export const resources: Resource[] = [
         keywords: ['voice ai', 'ai agent', 'chatbot', 'voice assistant', 'website widget'],
     },
     {
+        name: 'AnyAPI',
+        description:
+            'Hundreds of scraping and data APIs behind one key and one normalized JSON schema, priced per request in USD with no subscription.',
+        categories: ['Scraping', 'Social Media', 'Tooling'],
+        url: 'https://getanyapi.com',
+        keywords: ['scraping', 'data api', 'serp', 'social media data', 'api marketplace', 'mcp'],
+    },
+    {
         name: 'AnyGradient',
         description:
             'NextGen gradient generator with OKLCH interpolation, Display-P3 color support, customizable noise, and production-ready code exports',


### PR DESCRIPTION
Adds AnyAPI to `resources/a.ts`, alphabetically between AnveVoice and AnyGradient.

AnyAPI is a gateway that puts hundreds of third-party scraping and data APIs behind one key and one normalized JSON schema, billed per request in USD with no subscription. A developer discovers an API by natural-language query, reads its input/output JSON Schema and exact price, then calls it.

**Against the acceptance criteria:**

- **For developers** - it is an HTTP API and an MCP server; the audience is people writing code.
- **Main product only** - the API is the whole product, not a feature of something larger.
- **Available now** - no waitlist. A stranger gets a working key with starter credit from one unauthenticated call:
  ```
  curl -s -X POST https://api.getanyapi.com/agent/signup -d '{}'
  ```
  and the catalog needs no credential at all:
  ```
  curl -s 'https://api.getanyapi.com/catalog/search?q=instagram%20profile'
  ```
- **Custom domain, https, clean URL** - https://getanyapi.com, homepage not a deep link.
- **Documented** - https://getanyapi.com/docs, OpenAPI 3 at https://api.getanyapi.com/openapi.json.

Categories: `Scraping`, `Social Media`, `Tooling`.

Per CONTRIBUTING, it also exposes a public API, so I opened marcelscruz/public-apis#1192 as well - not a duplicate.

`npx prettier --check` and `npx tsc --noEmit` both pass locally.

Disclosure: I work on AnyAPI.