### PR TITLE
Add SaaSCity

### DIFF
--- a/db/resources.json
+++ b/db/resources.json
@@ -1,5 +1,5 @@
 {
-"count": 1196,
+"count": 1197,
 "data": [
     {
         "name": "1001 Fonts",
@@ -11228,6 +11228,21 @@
             "community",
             "seo",
             "growth"
+        ]
+    },
+    {
+        "name": "SaaSCity",
+        "description": "SaaSCity is a directory for launching SaaS and AI products, rendered as an isometric city map where every listing becomes a building.",
+        "categories": [
+            "Marketing",
+            "Startup"
+        ],
+        "url": "https://saascity.io/",
+        "keywords": [
+            "directory",
+            "launch",
+            "seo",
+            "backlinks"
         ]
     },
     {


### PR DESCRIPTION
Adding SaaSCity to `db/resources.json` (leaving the auto-generated `README.md` and `/db` output untouched as CONTRIBUTING asks).

**[SaaSCity](https://saascity.io)** — a directory for launching SaaS and AI products, rendered as an isometric city map where every listing becomes a building rather than a table row. Free submission, dofollow listing pages.

Filed under Marketing + Startup, inserted in alphabetical position next to the other SaaS* entries, `count` bumped to 1197.

https://claude.ai/code/session_01Q5fe2WDywQtBgHnQ8PXr5m