### PR TITLE
Add JobsPipe

### DIFF
--- a/resources/j.ts
+++ b/resources/j.ts
@@ -78,6 +78,14 @@ export const resources: Resource[] = [
         keywords: ['remote jobs', 'remote work', 'jobs', 'employment'],
     },
     {
+        name: 'JobsPipe',
+        description:
+            'Job postings from 30+ ATS and job boards, deduplicated into one JSON schema with salary, seniority and tech stack fields. REST API, CLI and Python/Go SDKs.',
+        categories: ['Job', 'Scraping'],
+        url: 'https://jobspipe.dev',
+        keywords: ['jobs api', 'job postings', 'job data', 'ats', 'tech stack'],
+    },
+    {
         name: 'Jobspresso',
         description:
             'Jobspresso is the easiest way to find remote jobs and careers at interesting and innovative companies.',


### PR DESCRIPTION
Adds JobsPipe to `resources/j.ts`, between `Jobicy` and `Jobspresso`.

```ts
{
    name: 'JobsPipe',
    description:
        'Job postings from 30+ ATS and job boards, deduplicated into one JSON schema with salary, seniority and tech stack fields. REST API, CLI and Python/Go SDKs.',
    categories: ['Job', 'Scraping'],
    url: 'https://jobspipe.dev',
    keywords: ['jobs api', 'job postings', 'job data', 'ats', 'tech stack'],
},
```

## Checklist

- [x] Changes made in the `resources` folder, not the auto-generated `README.md` or `db`
- [x] Highly related to programming and development — a developer API with a CLI and Python/Go SDKs
- [x] Meets the *What we accept* criteria: for developers, main product, custom domain, clean URL, available now (self-serve free tier, no waitlist)
- [x] Formatted per the contributing guide — `prettier --check` passes with the repo config; `tsc --noEmit -p tsconfig.json` passes, so both categories are valid `Category` members
- [x] Alphabetical by `name`: `Jobicy` → `JobsPipe` → `Jobspresso`
- [x] Description is 155 characters (limit 160)
- [x] URL starts with `https://` and is the homepage, not a docs deep-link
- [x] Searched the repo — no existing JobsPipe entry, issue, or PR

On categories: `'Job'` is the obvious one. `'Scraping'` because the product is the licensed alternative to scraping job boards yourself, which is where developers looking for it tend to be searching. Happy to drop it if you'd rather keep that category to scraping tools proper.

Per the contributing guide's note that a listing here is not a duplicate of one in `public-apis`, the API side is already listed there (and I've opened marcelscruz/public-apis#1195 to merge the two duplicate entries it had).

## Disclosure

I maintain JobsPipe. It is a commercial product with a self-serve free tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)