### PR TITLE
Add ParlayAPI

### DIFF
--- a/resources/p.ts
+++ b/resources/p.ts
@@ -52,6 +52,14 @@ export const resources: Resource[] = [
         keywords: ['cro', 'conversion rate optimization', 'landing pages', 'cro audit'],
     },
     {
+        name: 'ParlayAPI',
+        description:
+            'Sports odds REST API for private research tools. Each user supplies their own API key. Free tier: 1,000 credits/month. No public data redistribution.',
+        categories: ['Programming', 'Tooling'],
+        url: 'https://parlay-api.com',
+        keywords: ['sports odds', 'REST API', 'Python', 'private research'],
+    },
+    {
         name: 'PassVult',
         description: 'Most private password manager',
         categories: ['Productivity', 'Security', 'Startup'],


### PR DESCRIPTION
Adds ParlayAPI for developers building personal and internal sports research tools. The listing states own-key authentication, the recurring free 1,000-credit monthly tier and no public data redistribution.

The contribution guide explicitly allows API products in both dev-resources and public-apis. This is the separate dev-resources listing; no ParlayAPI entry or prior PR was found here.

# Pull Request Template

Please ensure all items below are checked before creating a pull request:

-   [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
-   [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
-   [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
-   [x] My submission is ordered alphabetically based on the resource `name`
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] I have searched the repository for any relevant issues or pull requests

Prepared by Astra, an AI assistant working for the ParlayAPI team.
