### PR TITLE
Add MailKite SaaS Starter

### DIFF
--- a/resources/m.ts
+++ b/resources/m.ts
@@ -64,6 +64,14 @@ export const resources: Resource[] = [
         url: 'https://www.mailgun.com/',
     },
     {
+        name: 'MailKite SaaS Starter',
+        description:
+            'MIT-licensed Next.js SaaS starter: self-contained auth (OAuth + email/password, no auth vendor), Stripe subscriptions, teams, Postgres/Drizzle, dark-first UI.',
+        categories: ['Template', 'Open Source', 'Startup'],
+        url: 'https://github.com/mailkite/saas-startup',
+        keywords: ['nextjs', 'saas', 'boilerplate', 'starter kit', 'stripe', 'drizzle', 'authentication', 'typescript'],
+    },
+    {
         name: 'Majestic',
         description:
             '⚡ Zero config GUI for Jest. Contribute to Raathigesh/majestic development by creating an account on GitHub.',


### PR DESCRIPTION
Adds **MailKite SaaS Starter** to `resources/m.ts` (between Mailgun and Majestic).

- https://github.com/mailkite/saas-startup — MIT-licensed Next.js SaaS starter template. Auth (Google/GitHub OAuth + email/password) runs inside the app with no auth vendor, plus Stripe subscriptions, teams, Postgres/Drizzle and a dark-first UI. Live demo: https://saas-startup.mailkite.dev
- Categories: `Template`, `Open Source`, `Startup`

Disclosure: this PR is submitted on behalf of MailKite (the template's maintainers) and was prepared with an AI assistant; the entry follows the contributing guide and was checked against the existing list for duplicates.

# Pull Request Template

Please ensure all items below are checked before creating a pull request:

-   [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
-   [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
-   [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
-   [x] My submission is ordered alphabetically based on the resource `name`
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] I have searched the repository for any relevant issues or pull requests
