### PR TITLE
Add Tools in a Tab developer utilities

### DIFF
--- a/resources/t.ts
+++ b/resources/t.ts
@@ -368,6 +368,14 @@ export const resources: Resource[] = [
         ],
     },
     {
+        name: 'Tools in a Tab',
+        description:
+            'Free browser tools for JSON, YAML, Base64, Unix timestamps and SHA-256. Local input processing, no account required; English and Spanish.',
+        categories: ['Tooling', 'Productivity'],
+        url: 'https://toolsinatab.com/',
+        keywords: ['json', 'yaml', 'base64', 'timestamp', 'sha256'],
+    },
+    {
         name: 'ToolSuite',
         description:
             'ToolSuite provides free in-browser developer utilities including Base64 encoder, Unix timestamp converter, JSON formatter, and image optimization tools.',


### PR DESCRIPTION
# Add Tools in a Tab

I maintain Tools in a Tab. It is a free collection of browser-based developer utilities, including JSON/YAML validation, Base64, Unix timestamps, SHA-256 and IPv4 conversions. The tools process their inputs locally and do not require an account. The site is available in English and Spanish.

This adds only the product listing in `resources/t.ts`; it does not submit the site's source code. The site has optional consent-based analytics, so this submission does not claim that the entire site makes no network requests.

## Checklist

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is highly related to programming and development
- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My submission is ordered alphabetically based on the resource name
- [x] My submission has a useful description
- [x] The URL starts with HTTPS and points to the product's homepage
- [x] I have searched the repository for relevant issues or pull requests

## Validation

- Description: 137 characters; two existing categories (`Tooling`, `Productivity`).
- No match for the product name or domain in the current resources/README or the issue/PR searches performed.
- TypeScript parse check: no syntax diagnostics.
- New entry checked with Prettier against the repository's formatting options; unrelated entries were not reformatted.
- `git diff --check`: passed.
- Existing repository-wide tests/lint were not run for this metadata-only addition.
