### PR TITLE
Add PastAGI

### DIFF
--- a/resources/p.ts
+++ b/resources/p.ts
@@ -67,6 +67,14 @@ export const resources: Resource[] = [
         keywords: ['cybersecurity', 'password manager', 'privacy', 'loyalty card'],
     },
     {
+        name: 'PastAGI',
+        description:
+            'Practical AI engineering publication: LLM inference cost audits, serving math, eval methodology, and tool reviews with verifiable numbers.',
+        categories: ['Blog', 'AI'],
+        url: 'https://pastagi.com',
+        keywords: ['ai engineering', 'llm', 'inference cost', 'evals', 'tutorials'],
+    },
+    {
         name: 'Patterninja',
         description:
             'Combine images from our free library or use your own. Produced patterns can be downloaded in high resolution and used for printing and the web.',


### PR DESCRIPTION
Adds [PastAGI](https://pastagi.com) to `resources/p.ts` (alphabetical, between PassVult and Patterninja).

PastAGI is a practical AI-engineering publication: LLM inference cost audits, serving math, eval methodology, and tool reviews with verifiable numbers. Developer-audience content, so I filed it under `Blog` + `AI`.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name`
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
- [x] I have searched the repository for any relevant issues or pull requests
