### PR TITLE
Add ResumeAI to Resume category

### DIFF
--- a/resources/r.ts
+++ b/resources/r.ts
@@ -389,6 +389,14 @@ export const resources: Resource[] = [
         url: 'https://resume.io',
     },
     {
+        name: 'ResumeAI',
+        description:
+            'Free ATS resume checker (3/day anonymous, 10/day free account) plus the open State of ATS 2026 employer dataset.',
+        categories: ['Resume', 'Job'],
+        url: 'https://withresumeai.com/',
+        keywords: ['ats', 'resume checker', 'job search', 'ats score'],
+    },
+    {
         name: 'ResumeBoostAI',
         description: 'Create a professional resume using AI.',
         categories: ['Resume', 'AI'],


### PR DESCRIPTION
## Summary
Adds [ResumeAI](https://withresumeai.com/) — free ATS resume checker (3 checks/day anonymous, 10/day with a free account) and the open [State of ATS 2026](https://withresumeai.com/reports/state-of-ats-2026) dataset (738 large employers, 704 portal-verified; Workday share 37.9%).

## Why
Fits the existing resume / ATS / job-search tools section next to peer checkers and builders.

## Notes
- Small, single-list addition
- Canonical facts only (no invented ATS stats)
- Happy to adjust section/wording if preferred

Author: Kayvan Zahiri · kayvan@withresumeai.com
