### PR TITLE
Add Nick Launches

### DIFF
--- a/resources/n.ts
+++ b/resources/n.ts
@@ -151,6 +151,14 @@ export const resources: Resource[] = [
         keywords: ['SEO', 'Marketing'],
     },
     {
+        name: 'Nick Launches',
+        description:
+            'Launch directory for indie makers and startups. Submit a product, get it listed in a browsable catalogue, and earn a dofollow backlink.',
+        categories: ['Marketing', 'Startup', 'SEO'],
+        url: 'https://nicklaunches.com',
+        keywords: ['launch', 'directory', 'startup', 'backlink', 'indie'],
+    },
+    {
         name: 'Nitric',
         description: 'A fun and productive framework for building serverless apps',
         categories: ['API Building'],


### PR DESCRIPTION
Adds [Nick Launches](https://nicklaunches.com) to `resources/n.ts`.

It is a launch directory for indie makers and startups: submit a product, it gets listed in a browsable catalogue, and the listing carries a dofollow backlink. Same shape as BetaList, Best Directories and AI Directories, which are already in the list.

Categories: `Marketing`, `Startup`, `SEO`.

- [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
- [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
- [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My submission is ordered alphabetically based on the resource `name` (between Niche Tools and Nitric)
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
- [x] I have searched the repository for any relevant issues or pull requests

Prettier check passes on the modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAoCb4qfuFDofQEg2RcadM