### PR TITLE
Add Image to ASCII

### DIFF
--- a/resources/i.ts
+++ b/resources/i.ts
@@ -109,6 +109,14 @@ export const resources: Resource[] = [
         url: 'https://www.artify.co/illustrations-figma',
     },
     {
+        name: 'Image to ASCII',
+        description:
+            'Convert images locally into ASCII art for READMEs and terminals. Copy text or Markdown; export TXT, PNG, SVG, HTML, or ANSI. Free, no signup.',
+        categories: ['Image', 'Terminal', 'Tooling'],
+        url: 'https://imagetoascii.art/',
+        keywords: ['ascii art', 'image to ascii', 'readme', 'ansi', 'markdown', 'local processing'],
+    },
+    {
         name: 'Img.Upscaler',
         description: 'Upscale and enhance your image by using the latest AI technology. Support batch process.',
         categories: ['AI', 'Image'],


### PR DESCRIPTION
Adds Image to ASCII, a free browser tool for creating character art for GitHub READMEs and terminal output. Images are processed locally; users can copy text or Markdown and export TXT, PNG, SVG, HTML, or ANSI.

This submission is on behalf of the product owner. The tool is available without signup at its own HTTPS domain. The entry uses the existing Image, Terminal, and Tooling categories; Semaphore is an existing but distinct ASCII converter.

- [x] Changes are in `resources`, not the generated README or db.
- [x] Developer use cases include README assets and ANSI terminal artwork.
- [x] Reviewed the acceptance criteria; product is live on its own domain.
- [x] Formatted according to the contribution guide.
- [x] Entry is ordered alphabetically by name.
- [x] Description is useful and under 160 characters.
- [x] URL is the canonical HTTPS homepage without query parameters.
- [x] Searched repository, issues, and PRs for duplicates.

Validation: Prettier check and `git diff --check` pass. `tsc --noEmit` reports an existing error in `resources/t.ts:210` (`'Tool'` is not assignable to `Category`); that entry is unchanged by this PR.
