### PR TITLE
Add inboxsink

### DIFF
--- a/resources/i.ts
+++ b/resources/i.ts
@@ -123,6 +123,14 @@ export const resources: Resource[] = [
         url: 'https://imgupscaler.com',
     },
     {
+        name: 'inboxsink',
+        description:
+            'Disposable email inboxes for end-to-end tests. A wait endpoint blocks until the email arrives and returns the verification code or confirmation link already extracted.',
+        categories: ['Testing'],
+        url: 'https://inboxsink.com',
+        keywords: ['email testing', 'disposable email', 'otp', 'magic link', 'playwright', 'cypress', 'selenium', 'e2e'],
+    },
+    {
         name: 'IncidentHub',
         description:
             'Monitors the third-party Cloud and SaaS services that your application and team depend on. The Free (forever) tier has 20 services and 2 channels (Discord and Slack) for notifications.',


### PR DESCRIPTION
Adds [inboxsink](https://inboxsink.com) to `resources/i.ts` (category **Testing**), before IncidentHub.

Disposable email inboxes for end-to-end tests: a `wait` endpoint blocks until the email arrives and returns the verification code or confirmation link already extracted. Self-serve, free tier of 1,000 API calls a month, guides for Playwright, Cypress and Selenium at https://inboxsink.com/guides.

-   [x] My changes were made in the `resources` folder, not in the auto-generated `README.md` file or `db` folder
-   [x] The resource is _highly_ or _exclusively_ related to **programming** and **development**
-   [x] My submission meets the What we accept criteria in the [contributing guide](CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
-   [x] My submission is ordered alphabetically based on the resource `name`
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the product's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] I have searched the repository for any relevant issues or pull requests

Disclosure: opened by the maintainer of inboxsink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzYjYTiK9zLmVqLpLKUPA8